### PR TITLE
feat: node選択画面・ホレリス章・消耗カードメカニクス

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -464,35 +464,35 @@
 
     /* ── Hand ──────────────────────────────────────────────────────────── */
     .hand-scroll {
-      width: 100%; overflow-x: auto; overflow-y: visible;
-      -webkit-overflow-scrolling: touch;
+      width: 100%; overflow: visible;
       padding: 0.25rem 0.2rem 0.1rem; box-sizing: border-box;
     }
     .hand {
       --card-w: 96px; --card-h: 170px;
       display: flex; flex-wrap: nowrap; justify-content: center;
-      align-items: flex-end; gap: 0.4rem;
+      align-items: flex-end; gap: 0;
       min-height: calc(var(--card-h) + 2rem);
       padding: 0.4rem 0.5rem 0.4rem;
-      width: max-content;
-      min-width: min(100%, calc(var(--n-cards, 1) * var(--card-w) + (var(--n-cards, 1) - 1) * 0.4rem + 1rem));
+      width: 100%;
       margin: 0 auto; position: relative; perspective: 800px;
       touch-action: pan-x pan-y;
     }
     @media (max-width: 420px) { .hand { --card-w: 80px; --card-h: 155px; } }
 
-    /* Card slot (wrapper that fan-rotates, includes cost badge above) */
+    /* Card slot — flat layout with optional overlap, no tilt */
     .hand .card-slot {
       position: relative;
       flex: 0 0 var(--card-w); width: var(--card-w); min-width: var(--card-w);
       display: flex; flex-direction: column; align-items: center;
       transform-origin: 50% 100%;
-      transform: translateY(calc(-1 * var(--peek-lift, 0px))) rotate(var(--rot, 0deg));
+      transform: translateY(calc(-1 * var(--peek-lift, 0px)));
       transition: transform 0.2s ease, filter 0.15s;
       z-index: var(--i, 1);
       cursor: default;
       --peek-lift: 0px;
+      margin-left: var(--card-margin, 0.4rem);
     }
+    .hand .card-slot:first-child { margin-left: 0; }
     .hand .card-slot:hover:not(.card-slot--disabled) { z-index: 80; filter: brightness(1.04); }
     .hand .card-slot--focused { z-index: 90 !important; filter: brightness(1.06); }
     .hand .card-slot--focused .card {
@@ -644,60 +644,175 @@
     /* ── Node Select View ──────────────────────────────────────────────── */
     #nodeSelectView {
       display: flex; flex-direction: column;
-      align-items: center; justify-content: center;
-      min-height: 60vh;
-      padding: 1.5rem 1rem;
+      align-items: center;
+      padding: 1rem 0.5rem 1.5rem;
+      background: none;
+      border: none;
     }
-    .ns-header { text-align: center; margin-bottom: 2rem; }
-    .ns-header h2 { margin: 0 0 0.4rem; font-size: 1.3rem; color: var(--accent); }
-    .ns-sub { margin: 0; font-size: 0.82rem; color: var(--muted); }
+    .ns-header { text-align: center; margin-bottom: 1.2rem; }
+    .ns-header h2 { margin: 0 0 0.3rem; font-size: 1.2rem; color: var(--accent); }
+    .ns-sub { margin: 0; font-size: 0.78rem; color: var(--muted); }
 
-    .ns-path {
-      display: flex; flex-wrap: wrap;
-      align-items: center; justify-content: center;
-      gap: 0.5rem 0.3rem;
-      width: 100%;
+    /* Horizontal scroll row of chapter cards */
+    .ns-cards {
+      display: flex; flex-wrap: nowrap;
+      gap: 0.75rem;
+      width: 100%; overflow-x: auto;
+      padding: 0.5rem 0.25rem 1rem;
+      -webkit-overflow-scrolling: touch;
+      scroll-snap-type: x mandatory;
+      align-items: flex-start;
     }
 
-    .ns-node {
-      display: flex; flex-direction: column; align-items: center;
-      padding: 0.9rem 1.1rem;
-      border-radius: 12px;
+    /* Each chapter card */
+    .ns-card {
+      flex: 0 0 160px;
+      width: 160px;
+      border-radius: 14px;
       border: 2px solid var(--border);
-      background: var(--map-node);
-      min-width: 100px;
-      transition: transform 0.12s, border-color 0.12s, box-shadow 0.12s;
+      overflow: hidden;
+      position: relative;
       cursor: default;
+      scroll-snap-align: center;
+      transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
+      min-height: 260px;
+      display: flex; flex-direction: column;
     }
-    .ns-node--unlocked {
+    @media (max-width: 420px) {
+      .ns-card { flex: 0 0 140px; width: 140px; min-height: 235px; }
+    }
+
+    /* Background image layer */
+    .ns-card-bg {
+      position: absolute; inset: 0;
+      background-image: var(--ns-bg);
+      background-size: cover; background-position: center top;
+      opacity: 0.38;
+      z-index: 0;
+    }
+
+    /* Content sits above bg */
+    .ns-card-body {
+      position: relative; z-index: 1;
+      display: flex; flex-direction: column;
+      width: 100%; flex: 1;
+    }
+
+    /* Node name header */
+    .ns-card-title {
+      background: rgba(8,6,16,0.88);
+      color: var(--accent);
+      font-weight: 800; font-size: 0.78rem;
+      text-align: center;
+      padding: 0.4rem 0.3rem;
+      letter-spacing: 0.03em;
+    }
+
+    /* Enemy row */
+    .ns-enemy-row {
+      display: flex; flex-wrap: wrap;
+      justify-content: center; align-items: flex-end;
+      gap: 2px;
+      padding: 0.4rem 0.2rem 0.2rem;
+      flex: 1;
+      background: rgba(0,0,0,0.18);
+    }
+    .ns-enemy-img {
+      width: 56px; height: 56px;
+      object-fit: contain; image-rendering: pixelated;
+      filter: drop-shadow(0 2px 4px #000a);
+    }
+    @media (max-width: 420px) {
+      .ns-enemy-img { width: 46px; height: 46px; }
+    }
+
+    /* Boss row */
+    .ns-boss-row {
+      display: flex; flex-direction: column; align-items: center;
+      background: rgba(6,4,14,0.85);
+      padding: 0.3rem 0.25rem 0.35rem;
+      gap: 0.1rem;
+    }
+    .ns-boss-label {
+      font-size: 0.62rem; font-weight: 800;
+      color: #ff5555; letter-spacing: 0.08em; text-transform: uppercase;
+    }
+    .ns-boss-img {
+      width: 64px; height: 64px;
+      object-fit: contain; image-rendering: pixelated;
+      filter: drop-shadow(0 2px 6px #000c);
+    }
+    @media (max-width: 420px) {
+      .ns-boss-img { width: 54px; height: 54px; }
+    }
+    .ns-boss-name {
+      font-size: 0.62rem; color: #c8b8e0;
+      text-align: center; line-height: 1.2; font-weight: 600;
+    }
+
+    /* Cleared badge */
+    .ns-cleared-badge {
+      font-size: 0.6rem; font-weight: 700;
+      color: var(--gain); text-align: center;
+      padding: 0.2rem 0;
+      background: rgba(0,0,0,0.6);
+    }
+
+    /* State variants */
+    .ns-card--unlocked {
       border-color: var(--accent);
       cursor: pointer;
     }
-    .ns-node--unlocked:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 8px 20px #0008;
-      border-color: #e8d070;
+    .ns-card--unlocked:hover, .ns-card--unlocked:focus {
+      transform: translateY(-5px) scale(1.02);
+      box-shadow: 0 10px 28px #000a, 0 0 0 2px var(--accent);
+      outline: none;
     }
-    .ns-node--cleared {
-      border-color: var(--gain);
-      opacity: 0.7;
+    .ns-card--cleared {
+      border-color: #4caf6a;
+      cursor: pointer;
     }
-    .ns-node--locked {
-      opacity: 0.45;
+    .ns-card--cleared:hover, .ns-card--cleared:focus {
+      transform: translateY(-3px);
+      box-shadow: 0 6px 18px #000a;
+      outline: none;
     }
-    .ns-node--troy {
-      border-color: #b060f0;
-      opacity: 0.55;
-      cursor: not-allowed;
-    }
+    .ns-card--locked .ns-card-bg { opacity: 0.15; }
+    .ns-card--locked .ns-card-body { opacity: 0.5; }
+    .ns-card--locked { border-color: #2a2438; }
 
-    .ns-node-icon { font-size: 1.5rem; line-height: 1; margin-bottom: 0.35rem; }
-    .ns-node-name { font-size: 0.82rem; font-weight: 700; color: var(--text); text-align: center; }
-    .ns-node-hint { font-size: 0.7rem; color: var(--muted); margin-top: 0.2rem; }
+    .ns-card--troy { border-color: #6030a0; }
+    .ns-card--troy .ns-card-bg { opacity: 0.2; }
+    .ns-card--troy .ns-card-body { opacity: 0.55; }
 
-    .ns-arrow {
-      font-size: 1.4rem; color: var(--muted);
-      flex-shrink: 0;
+    /* Lock overlay */
+    .ns-card-lock-overlay {
+      flex: 1; display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      gap: 0.4rem; padding: 1rem;
+      background: rgba(0,0,0,0.4);
+    }
+    .ns-lock-icon { font-size: 1.8rem; }
+    .ns-lock-label { font-size: 0.7rem; color: var(--muted); }
+
+    /* TROY lock */
+    .ns-card-troy-lock {
+      flex: 1; display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      gap: 0.5rem; padding: 1rem;
+    }
+    .ns-card-troy-lock span:first-child { font-size: 2rem; color: #9060d0; }
+    .ns-card-troy-label { font-size: 0.72rem; color: #8060b0; font-weight: 700; }
+
+    /* Just-unlocked glow animation */
+    .ns-card--just-unlocked {
+      animation: ns-unlock-glow 1.6s ease-out forwards;
+    }
+    @keyframes ns-unlock-glow {
+      0%  { box-shadow: 0 0 0 0 #c4a35a00; border-color: var(--accent); }
+      20% { box-shadow: 0 0 24px 8px #c4a35a88; border-color: #fff; transform: scale(1.05); }
+      60% { box-shadow: 0 0 16px 4px #c4a35a44; border-color: #e8d070; transform: scale(1.02); }
+      100%{ box-shadow: none; border-color: var(--accent); transform: scale(1); }
     }
 
     /* Reward cards (keep original layout style) */
@@ -1197,7 +1312,7 @@
 
     </div>
 
-    <div id="nodeSelectView" class="panel hidden"></div>
+    <div id="nodeSelectView" class="hidden"></div>
 
     <div id="shopView" class="panel hidden">
       <div class="shop-header-row">

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -186,6 +186,11 @@
       image-rendering: crisp-edges;
       pointer-events: none;
     }
+    .map-node-icon-img {
+      pointer-events: none;
+      image-rendering: pixelated;
+      image-rendering: crisp-edges;
+    }
     .map-legend {
       font-size: 0.72rem;
       color: var(--muted);
@@ -512,18 +517,21 @@
     }
     .card-cost-above .cost-zeus { font-size: 0.8rem; }
 
-    /* Card cost color variants */
-    .card-slot[data-cost="0"] .card-cost-above { border-color: #4a4060; }
-    .card-slot[data-cost="1"] .card { border-color: #3a6ab0; }
-    .card-slot[data-cost="1"] .card-cost-above { border-color: #3a6ab0; border-bottom: none; }
-    .card-slot[data-cost="2"] .card { border-color: #2a9070; }
-    .card-slot[data-cost="2"] .card-cost-above { border-color: #2a9070; border-bottom: none; }
-    .card-slot[data-cost="3"] .card { border-color: #c4a35a; }
-    .card-slot[data-cost="3"] .card-cost-above { border-color: #c4a35a; border-bottom: none; }
-    .card-slot[data-cost="4"] .card { border-color: #c05050; }
-    .card-slot[data-cost="4"] .card-cost-above { border-color: #c05050; border-bottom: none; }
-    .card-slot[data-cost="5"] .card { border-color: #a03040; }
-    .card-slot[data-cost="5"] .card-cost-above { border-color: #a03040; border-bottom: none; }
+    /* Card rarity color variants
+       Common=#0984E3 / Uncommon=#00B894 / Rare=#FDCB6E / Epic=#E17055 / Legendary=#D63031 */
+    .card-slot[data-rarity="common"]    .card { border-color: #0984E3; }
+    .card-slot[data-rarity="common"]    .card-cost-above { border-color: #0984E3; border-bottom: none; }
+    .card-slot[data-rarity="uncommon"]  .card { border-color: #00B894; }
+    .card-slot[data-rarity="uncommon"]  .card-cost-above { border-color: #00B894; border-bottom: none; }
+    .card-slot[data-rarity="rare"]      .card { border-color: #FDCB6E; }
+    .card-slot[data-rarity="rare"]      .card-cost-above { border-color: #FDCB6E; border-bottom: none; }
+    .card-slot[data-rarity="epic"]      .card { border-color: #E17055; }
+    .card-slot[data-rarity="epic"]      .card-cost-above { border-color: #E17055; border-bottom: none; }
+    .card-slot[data-rarity="legendary"] .card { border-color: #D63031; }
+    .card-slot[data-rarity="legendary"] .card-cost-above { border-color: #D63031; border-bottom: none; }
+    /* fallback when data-rarity not set */
+    .card-slot:not([data-rarity]) .card { border-color: #0984E3; }
+    .card-slot:not([data-rarity]) .card-cost-above { border-color: #0984E3; border-bottom: none; }
 
     /* Card base */
     .card {

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -344,7 +344,7 @@
       bottom: 100%;
       transform: translateX(-50%) translateY(0);
       font-weight: 800;
-      font-size: 0.95rem;
+      font-size: 1.8rem;
       pointer-events: none;
       opacity: 0;
       white-space: nowrap;
@@ -546,6 +546,8 @@
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
       flex-shrink: 0;
     }
+    .exhaust-badge { font-size: 0.55rem; margin-left: 2px; vertical-align: middle; }
+    .card--exhaust { border-color: #a04020 !important; }
     .card-icon-area {
       position: relative; flex: 1; overflow: hidden; min-height: 0;
     }
@@ -625,6 +627,77 @@
       font-size: 1rem;
       color: var(--energy);
       font-variant-numeric: tabular-nums;
+    }
+
+    /* ── Exhaust count ─────────────────────────────────────────────────── */
+    .exhaust-count {
+      display: inline-flex; align-items: center; gap: 0.2rem;
+      font-size: 0.75rem; color: var(--muted);
+      margin-right: auto;
+      opacity: 0.8;
+    }
+    .exhaust-count[data-nonzero="true"] {
+      color: #e07040;
+      opacity: 1;
+    }
+
+    /* ── Node Select View ──────────────────────────────────────────────── */
+    #nodeSelectView {
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      min-height: 60vh;
+      padding: 1.5rem 1rem;
+    }
+    .ns-header { text-align: center; margin-bottom: 2rem; }
+    .ns-header h2 { margin: 0 0 0.4rem; font-size: 1.3rem; color: var(--accent); }
+    .ns-sub { margin: 0; font-size: 0.82rem; color: var(--muted); }
+
+    .ns-path {
+      display: flex; flex-wrap: wrap;
+      align-items: center; justify-content: center;
+      gap: 0.5rem 0.3rem;
+      width: 100%;
+    }
+
+    .ns-node {
+      display: flex; flex-direction: column; align-items: center;
+      padding: 0.9rem 1.1rem;
+      border-radius: 12px;
+      border: 2px solid var(--border);
+      background: var(--map-node);
+      min-width: 100px;
+      transition: transform 0.12s, border-color 0.12s, box-shadow 0.12s;
+      cursor: default;
+    }
+    .ns-node--unlocked {
+      border-color: var(--accent);
+      cursor: pointer;
+    }
+    .ns-node--unlocked:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 8px 20px #0008;
+      border-color: #e8d070;
+    }
+    .ns-node--cleared {
+      border-color: var(--gain);
+      opacity: 0.7;
+    }
+    .ns-node--locked {
+      opacity: 0.45;
+    }
+    .ns-node--troy {
+      border-color: #b060f0;
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+
+    .ns-node-icon { font-size: 1.5rem; line-height: 1; margin-bottom: 0.35rem; }
+    .ns-node-name { font-size: 0.82rem; font-weight: 700; color: var(--text); text-align: center; }
+    .ns-node-hint { font-size: 0.7rem; color: var(--muted); margin-top: 0.2rem; }
+
+    .ns-arrow {
+      font-size: 1.4rem; color: var(--muted);
+      flex-shrink: 0;
     }
 
     /* Reward cards (keep original layout style) */
@@ -1114,6 +1187,7 @@
           <div id="hand" class="hand" role="list"></div>
         </div>
         <div class="footer-bottombar">
+          <span class="exhaust-count" id="exhaustCount" title="消耗済みカード">🔥<span id="exhaustNum">0</span></span>
           <button type="button" class="btn-deck-pile" id="btnDeckOpen" aria-label="残りデッキを表示">
             <img alt="" data-icon="deck" width="20" height="20" />
             <span class="btn-deck-pile__count" id="deckPileCount">0</span>
@@ -1122,6 +1196,8 @@
       </div>
 
     </div>
+
+    <div id="nodeSelectView" class="panel hidden"></div>
 
     <div id="shopView" class="panel hidden">
       <div class="shop-header-row">

--- a/prototype/js/bosses.js
+++ b/prototype/js/bosses.js
@@ -18,6 +18,20 @@ export const BOSS_DEFS = {
     ],
   },
 
+  'boss-hl': {
+    id: 'boss-hl',
+    name: 'ゴースト・ビスマルク',
+    hp: 80, phy: 17, int: 9, agi: 7, imgId: 435,
+    initialShield: 0,
+    intentRota: [
+      { kind: 'attack',      phyPct: 100 },
+      { kind: 'guard',       value: 12 },
+      { kind: 'attackBleed', phyPct: 90, bleedStacks: 1 },
+      { kind: 'special',     pct: 12 },
+      { kind: 'buffSelf',    phyAdd: 3, intAdd: 2 },
+    ],
+  },
+
   'boss-ch2': {
     id: 'boss-ch2',
     name: 'ゴースト・ナポレオン',

--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -682,6 +682,143 @@ function makeCardLibrary(clog, api) {
     },
 
     // ════════════════════════════════════════
+    // 章 1 ── ホレリス カードプール
+    // ════════════════════════════════════════
+    cdH01: {
+      libraryKey: "cdH01",
+      extId: 2006,
+      extNameJa: "エリートカタナ",
+      skillNameJa: "抜刀・一閃",
+      skillIcon: "phy.png",
+      cost: 1,
+      type: "atk",
+      exhaust: true,
+      effectSummaryLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 80, 80);
+        return [`敵にダメージ　${d}`, "【消耗】"];
+      },
+      peekHelpKeys() { return []; },
+      previewLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 80, 80);
+        return [`敵1体に ${d} ダメージ（PHY 80%）`, "【消耗】使用後、山札に戻らず除外される"];
+      },
+      play(s) { api.dealPhySkillToEnemy(s, 80, 80); },
+    },
+
+    cdH02: {
+      libraryKey: "cdH02",
+      extId: 1002,
+      extNameJa: "ノービスマスケット",
+      skillNameJa: "出血弾・速射",
+      skillIcon: "phy.png",
+      cost: 1,
+      type: "atk",
+      effectSummaryLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 60, 60);
+        return [`敵にダメージ　${d}`, "出血　×1（敵）"];
+      },
+      peekHelpKeys() { return []; },
+      previewLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 60, 60);
+        return [`敵1体に ${d} ダメージ（PHY 60%）`, "敵に出血 ×1 付与"];
+      },
+      play(s) {
+        api.dealPhySkillToEnemy(s, 60, 60);
+        if (s.enemyHp > 0) api.addBleedToEnemy(s, 1);
+      },
+    },
+
+    cdH03: {
+      libraryKey: "cdH03",
+      extId: 2005,
+      extNameJa: "エリートホース",
+      skillNameJa: "疾風の構え",
+      skillIcon: "BUF_agi.png",
+      cost: 1,
+      type: "skl",
+      effectSummaryLines() { return ["ガード　+8", "AGI　+2（永続）"]; },
+      peekHelpKeys() { return ["guard", "agi"]; },
+      previewLines() {
+        return ["ガードを 8 得る", "AGI を +2（永続）"];
+      },
+      play(s) {
+        se("buff"); fx("player", "buff");
+        s.playerGuard += 8;
+        s.playerAgi += 2;
+        clog("疾風の構え: ガード+8、AGI+2");
+      },
+    },
+
+    cdH04: {
+      libraryKey: "cdH04",
+      extId: 2003,
+      extNameJa: "エリートペン",
+      skillNameJa: "緊急回復",
+      skillIcon: "hp.png",
+      cost: 0,
+      type: "skl",
+      exhaust: true,
+      effectSummaryLines(s) {
+        const h = Math.floor((s.playerInt + s.playerPhy) / 2);
+        return [`HP　+${h}`, "【消耗】"];
+      },
+      peekHelpKeys() { return ["hp"]; },
+      previewLines(s) {
+        const h = Math.floor((s.playerInt + s.playerPhy) / 2);
+        return [`HP を ${h} 回復（(INT+PHY)÷2）`, "【消耗】使用後、山札に戻らず除外される"];
+      },
+      play(s) {
+        const heal = Math.floor((s.playerInt + s.playerPhy) / 2);
+        const before = s.playerHp;
+        s.playerHp = Math.min(s.playerHpMax, s.playerHp + heal);
+        if (s.playerHp > before) { se("heal"); fx("player", "heal"); }
+        clog(`緊急回復: HP+${s.playerHp - before}`);
+      },
+    },
+
+    cdH05: {
+      libraryKey: "cdH05",
+      extId: 1007,
+      extNameJa: "ノービスユミ",
+      skillNameJa: "連矢",
+      skillIcon: "phy.png",
+      cost: 1,
+      type: "atk",
+      effectSummaryLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 50, 50);
+        return [`敵にダメージ　${d} ×2`];
+      },
+      peekHelpKeys() { return []; },
+      previewLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 50, 50);
+        return [`敵1体に ${d} ×2 ダメージ（PHY 50% を 2 回）`];
+      },
+      play(s) {
+        api.dealPhySkillToEnemy(s, 50, 50);
+        if (s.enemyHp > 0) api.dealPhySkillToEnemy(s, 50, 50);
+      },
+    },
+
+    cdH06: {
+      libraryKey: "cdH06",
+      extId: 2008,
+      extNameJa: "エリートブック",
+      skillNameJa: "知識の爆発",
+      skillIcon: "int.png",
+      cost: 2,
+      type: "skl",
+      effectSummaryLines() { return ["INT　+2（永続）", "ドロー　3"]; },
+      peekHelpKeys() { return ["int", "draw"]; },
+      previewLines() { return ["INT を +2（永続）", "カードを 3 枚引く"]; },
+      play(s) {
+        se("buff"); fx("player", "buff");
+        s.playerInt += 2;
+        api.drawCards(s, 3);
+        clog("知識の爆発: INT+2、ドロー3");
+      },
+    },
+
+    // ════════════════════════════════════════
     // 章 2 ── 大航海の港 カードプール（SPEC-004 §7.4）
     // ════════════════════════════════════════
     cd201: {

--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -1062,3 +1062,64 @@ function shuffle(a) {
 }
 
 export { shuffle };
+
+/**
+ * カードレアリティ定義（SPEC §カードレアリティ）
+ * ここを編集するだけで全カードのレアリティ（枠色）を変更できます。
+ *
+ * 値: 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary'
+ * 色: common=#0984E3 / uncommon=#00B894 / rare=#FDCB6E / epic=#E17055 / legendary=#D63031
+ */
+export const CARD_RARITIES = {
+  // ─── スターターカード ──────────────────────────────────────────────
+  ext1001: 'common',    // ノービスブレード
+  ext1002: 'common',    // ノービスマスケット
+  ext1003: 'common',    // ノービスペン
+  ext1004: 'common',    // ノービスアーマー
+  ext1005: 'uncommon',  // ノービスホース（次ターンエナジー）
+  ext1006: 'common',    // ノービスカタナ
+  ext1008: 'uncommon',  // ノービスブック（INT+ドロー+ダメージ）
+  ext1011: 'common',    // アックス
+  ext1012: 'common',    // ETHEREMON-EKOPI
+  ext1022: 'uncommon',  // ドラゴン（全体+INT debuff）
+  ext1023: 'common',    // ブル（全体+自己PHYダウン）
+  ext2001: 'uncommon',  // エリートブレード
+  ext2002: 'uncommon',  // エリートマスケット（全体）
+  ext2004: 'uncommon',  // エリートアーマー（PHY%アップ）
+  ext2006: 'uncommon',  // エリートカタナ
+  ext2011: 'uncommon',  // エリートアックス
+  ext2013: 'uncommon',  // エリートユミ
+
+  // ─── 章0 アバカス カードプール ────────────────────────────────────
+  cd101:   'uncommon',  // 一刀（PHY100%）
+  cd102:   'rare',      // 二段斬り（PHY70%×2）
+  cd103:   'common',    // 構え（ガード+6）
+  cd104:   'uncommon',  // 集中（エナジー+1）
+  cd105:   'rare',      // 一閃（PHY150%）
+  cd106:   'uncommon',  // 鼓舞（PHY+3永続）
+  cd107:   'uncommon',  // 治療（HP回復）
+  cd108:   'uncommon',  // 突撃（コスト0+次ターンペナルティ）
+
+  // ─── 章1 ホレリス カードプール ────────────────────────────────────
+  cdH01:   'rare',      // 抜刀・一閃（PHY80%・消耗）
+  cdH02:   'uncommon',  // 出血弾・速射（PHY+出血×1）
+  cdH03:   'uncommon',  // 疾風の構え（ガード+8+AGI永続）
+  cdH04:   'rare',      // 緊急回復（コスト0・消耗）
+  cdH05:   'uncommon',  // 連矢（PHY50%×2）
+  cdH06:   'rare',      // 知識の爆発（INT+2+ドロー3）
+
+  // ─── 章2 アンティキティラ カードプール ───────────────────────────
+  cd301:   'uncommon',  // 鋼の盾（シールド+10）
+  cd302:   'epic',      // 大鎚（PHY200%）
+  cd303:   'epic',      // 戦術指揮（PHY+5+INT+5永続）
+  cd304:   'rare',      // 必殺の閃光（INT130%クリ確定）
+  cd305:   'rare',      // 不屈（このターン被ダメ半減）
+
+  // ─── 章3 アタナソフ カードプール ─────────────────────────────────
+  cd201:   'uncommon',  // 毒の刃（PHY+毒×2）
+  cd202:   'rare',      // 出血弾（PHY90%+出血×2）
+  cd203:   'common',    // 解毒（コスト0・デバフ解除）
+  cd204:   'rare',      // 防御陣（ガード+12）
+  cd205:   'rare',      // 連射（INT×3）
+  cd206:   'uncommon',  // 投資（GUM+20）
+};

--- a/prototype/js/chapters.js
+++ b/prototype/js/chapters.js
@@ -8,6 +8,7 @@ export const CHAPTERS = [
   {
     id: 1,
     name: 'node : アバカス',
+    bgId: '1023',
     mapRules: {
       layers: 4,
       nodesPerLayerMin: 3,
@@ -24,6 +25,7 @@ export const CHAPTERS = [
   {
     id: 2,
     name: 'node : ホレリス',
+    bgId: '1038',
     mapRules: {
       layers: 5,
       nodesPerLayerMin: 3,
@@ -40,6 +42,7 @@ export const CHAPTERS = [
   {
     id: 3,
     name: 'node : アンティキティラ',
+    bgId: '1037',
     mapRules: {
       layers: 5,
       nodesPerLayerMin: 3,
@@ -56,6 +59,7 @@ export const CHAPTERS = [
   {
     id: 4,
     name: 'node : アタナソフ',
+    bgId: '1053',
     mapRules: {
       layers: 5,
       nodesPerLayerMin: 3,

--- a/prototype/js/chapters.js
+++ b/prototype/js/chapters.js
@@ -4,6 +4,7 @@
  * 章 N の報酬プールは章 1〜N の cardPool を累積する（main.js 側で処理）。
  */
 export const CHAPTERS = [
+  // ─── 章 0 ─────────────────────────────────────────────────────────
   {
     id: 1,
     name: 'node : アバカス',
@@ -19,21 +20,23 @@ export const CHAPTERS = [
     bossId: 'boss-ch1',
     bossRewardGold: 50,
   },
+  // ─── 章 1 ─────────────────────────────────────────────────────────
   {
     id: 2,
-    name: 'node : アタナソフ',
+    name: 'node : ホレリス',
     mapRules: {
       layers: 5,
       nodesPerLayerMin: 3,
       nodesPerLayerMax: 5,
-      nodeRatios: { fight: 0.50, rest: 0.15, shop: 0.15, elite: 0.10, event: 0.10 },
+      nodeRatios: { fight: 0.55, rest: 0.15, shop: 0.10, elite: 0.12, event: 0.08 },
     },
-    enemyPool: ['vp-001', 'vp-002', 'vp-003'],
-    elitePool: ['vp-e01'],
-    cardPool: ['cd201', 'cd202', 'cd203', 'cd204', 'cd205', 'cd206'],
-    bossId: 'boss-ch2',
-    bossRewardGold: 80,
+    enemyPool: ['hl-001', 'hl-002', 'hl-003'],
+    elitePool: ['hl-e01'],
+    cardPool: ['cdH01', 'cdH02', 'cdH03', 'cdH04', 'cdH05', 'cdH06'],
+    bossId: 'boss-hl',
+    bossRewardGold: 70,
   },
+  // ─── 章 2 ─────────────────────────────────────────────────────────
   {
     id: 3,
     name: 'node : アンティキティラ',
@@ -47,6 +50,22 @@ export const CHAPTERS = [
     elitePool: ['en-e01'],
     cardPool: ['cd301', 'cd302', 'cd303', 'cd304', 'cd305'],
     bossId: 'boss-ch3',
+    bossRewardGold: 100,
+  },
+  // ─── 章 3 ─────────────────────────────────────────────────────────
+  {
+    id: 4,
+    name: 'node : アタナソフ',
+    mapRules: {
+      layers: 5,
+      nodesPerLayerMin: 3,
+      nodesPerLayerMax: 5,
+      nodeRatios: { fight: 0.50, rest: 0.15, shop: 0.15, elite: 0.10, event: 0.10 },
+    },
+    enemyPool: ['vp-001', 'vp-002', 'vp-003'],
+    elitePool: ['vp-e01'],
+    cardPool: ['cd201', 'cd202', 'cd203', 'cd204', 'cd205', 'cd206'],
+    bossId: 'boss-ch2',
     bossRewardGold: 120,
   },
 ];

--- a/prototype/js/enemies.js
+++ b/prototype/js/enemies.js
@@ -69,7 +69,48 @@ export const ENEMY_DEFS = {
   },
 
   /* ═══════════════════════════════════════
-     章 2 ── node : アタナソフ
+     章 2 ── node : ホレリス
+  ═══════════════════════════════════════ */
+  'hl-001': {
+    id: 'hl-001', name: 'ハートブリード ヴェンティ',
+    hp: 20, phy: 11, int: 5, agi: 8, imgId: 124,
+    intentRota: [
+      { kind: 'attack',      phyPct: 90 },
+      { kind: 'attackBleed', phyPct: 70, bleedStacks: 1 },
+      { kind: 'guard',       value: 6 },
+    ],
+  },
+  'hl-002': {
+    id: 'hl-002', name: 'バイトバンディット ヴェンティ',
+    hp: 22, phy: 14, int: 4, agi: 8, imgId: 164,
+    intentRota: [
+      { kind: 'attackBleed', phyPct: 85, bleedStacks: 1 },
+      { kind: 'guard',       value: 7 },
+      { kind: 'attack',      phyPct: 110 },
+    ],
+  },
+  'hl-003': {
+    id: 'hl-003', name: 'クリーパー マキアート',
+    hp: 18, phy: 10, int: 8, agi: 14, imgId: 105,
+    intentRota: [
+      { kind: 'attack', phyPct: 80 },
+      { kind: 'attack', phyPct: 80 },
+      { kind: 'guard',  value: 5 },
+    ],
+  },
+  // ★ レアエネミー
+  'hl-e01': {
+    id: 'hl-e01', name: 'ハートブリード フラペチーノ',
+    hp: 38, phy: 17, int: 6, agi: 10, imgId: 126,
+    intentRota: [
+      { kind: 'guard',       value: 10 },
+      { kind: 'attackBleed', phyPct: 100, bleedStacks: 2 },
+      { kind: 'attack',      phyPct: 120 },
+    ],
+  },
+
+  /* ═══════════════════════════════════════
+     章 3 ── node : アタナソフ
   ═══════════════════════════════════════ */
   'vp-001': {
     id: 'vp-001', name: 'カスケード ヴェンティ',

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -1203,16 +1203,29 @@ function renderCombat() {
   handFocusedIdx = -1;
   const n = combat.hand.length;
   handEl.style.setProperty("--n-cards", String(Math.max(n, 1)));
+
+  // カード重ね量を計算（横幅が足りない場合に重ねる）
+  const containerW = (handEl.parentElement?.clientWidth || 340) - 16;
+  const cardW = window.innerWidth <= 420 ? 80 : 96;
+  const minGapPx = 6; // 通常の gap（0.4rem ≈ 6px）
+  let cardMarginPx = minGapPx;
+  if (n > 1) {
+    const naturalW = cardW * n + minGapPx * (n - 1);
+    if (naturalW > containerW) {
+      // total = cardW + (n-1)*(cardW + margin) = containerW
+      // margin = (containerW - cardW) / (n - 1) - cardW
+      cardMarginPx = Math.floor((containerW - cardW) / (n - 1)) - cardW;
+      cardMarginPx = Math.max(cardMarginPx, -Math.floor(cardW * 0.58));
+    }
+  }
+  handEl.style.setProperty("--card-margin", cardMarginPx + "px");
+
   combat.hand.forEach((card, idx) => {
     const slot = document.createElement("div");
     slot.className = "card-slot" + (card.cost > combat.energy ? " card-slot--disabled" : "");
     slot.setAttribute("data-cost", String(card.cost));
     slot.style.setProperty("--i", String(idx + 1));
     slot.style.setProperty("--n", String(Math.max(n - 1, 1)));
-    const centerIdx = Math.floor((n - 1) / 2);
-    const rel = idx - centerIdx;
-    const rot = rel === 0 ? 0 : rel < 0 ? -4 * Math.abs(rel) : 4 * rel;
-    slot.style.setProperty("--rot", rot + "deg");
 
     const summaryLines = typeof card.effectSummaryLines === "function" ? card.effectSummaryLines(combat)
       : typeof card.previewLines === "function" ? card.previewLines(combat) : [card.text || ""];
@@ -1466,8 +1479,22 @@ function advanceAfterRewardPick(libraryKey) {
     runState.pathNodeIds.push(mid);
     runState.lastMapNodeId = mid;
     if (wasBoss) {
-      // 章クリア → 次章へ進む（advanceToNextChapter が runComplete を設定することも）
-      advanceToNextChapter();
+      // 章クリア → clearedChapters に追加し次章データを用意
+      const clearedIdx = runState.chapterIdx;
+      advanceToNextChapter(); // 内部で clearedChapters.add(clearedIdx) する
+      combat = null;
+      postCombatSnapshot = null;
+      if (runState.runComplete) {
+        // 全章クリア → ゲームオーバー画面（クリア）
+        showView("over");
+        document.getElementById("gameOverMsg").textContent =
+          "全 node クリアおめでとうございます！あなたは最高ですよ〜！";
+      } else {
+        // 次の node が解放された → node 選択画面へ（解放アニメ付き）
+        showView("nodeSelect");
+        renderNodeSelect(clearedIdx + 1); // 新たに解放されたインデックス
+      }
+      return;
     }
   }
   combat = null;
@@ -1615,64 +1642,114 @@ function startRunFromChapter(chapterIdx) {
   renderMap();
 }
 
-/** node 選択画面を描画する */
-function renderNodeSelect() {
+/**
+ * node 選択画面を描画する。
+ * @param {number|null} justUnlockedIdx  直前に解放された章インデックス（アニメ用、省略可）
+ */
+function renderNodeSelect(justUnlockedIdx = null) {
   const el = document.getElementById("nodeSelectView");
   if (!el) return;
 
   // CHAPTERS + ゴール「TROY」の構成
+  const TROY_BG_ID = '1052';
   const goals = [
     ...CHAPTERS.map((ch, idx) => ({ idx, name: ch.name.replace('node : ', ''), chapter: ch })),
-    { idx: CHAPTERS.length, name: 'TROY', chapter: null },
+    { idx: CHAPTERS.length, name: 'TROY', chapter: null, bgId: TROY_BG_ID },
   ];
 
   let html = '<div class="ns-header"><h2>node を選択してください</h2><p class="ns-sub">ボスを倒すと次の node が解放されます</p></div>';
-  html += '<div class="ns-path">';
+  html += '<div class="ns-cards">';
 
-  goals.forEach((goal, i) => {
-    const isLast = i === goals.length - 1; // TROY
-    const isUnlocked = goal.idx === 0 || clearedChapters.has(goal.idx - 1);
-    const isCleared  = clearedChapters.has(goal.idx);
-    const isTroy     = isLast;
+  goals.forEach((goal) => {
+    const isTroy     = goal.chapter === null;
+    const isUnlocked = !isTroy && (goal.idx === 0 || clearedChapters.has(goal.idx - 1));
+    const isCleared  = !isTroy && clearedChapters.has(goal.idx);
+    const isJustUnlocked = goal.idx === justUnlockedIdx;
 
-    let stateClass = isTroy ? 'ns-node--troy' :
-                     isCleared  ? 'ns-node--cleared' :
-                     isUnlocked ? 'ns-node--unlocked' :
-                                  'ns-node--locked';
+    const ch = goal.chapter;
+    const bgId = ch?.bgId ?? goal.bgId ?? '1001';
+    const bgUrl = img('Image/Backgrounds/' + bgId + '.png');
 
-    html += `<div class="ns-node ${stateClass}" data-idx="${goal.idx}" role="button" tabindex="${isUnlocked && !isTroy ? 0 : -1}">`;
-    html += `<div class="ns-node-icon">${isCleared ? '✓' : isTroy ? '★' : isUnlocked ? '▶' : '🔒'}</div>`;
-    html += `<div class="ns-node-name">${goal.name}</div>`;
+    // 状態クラス
+    const stateClass = isTroy      ? 'ns-card--troy' :
+                       isCleared   ? 'ns-card--cleared' :
+                       isUnlocked  ? 'ns-card--unlocked' :
+                                     'ns-card--locked';
+    const animClass  = isJustUnlocked ? ' ns-card--just-unlocked' : '';
+
+    html += `<div class="ns-card ${stateClass}${animClass}" data-idx="${goal.idx}" role="${isUnlocked ? 'button' : 'presentation'}" tabindex="${isUnlocked ? 0 : -1}" style="--ns-bg: url('${bgUrl}')">`;
+
+    // 背景レイヤー
+    html += '<div class="ns-card-bg"></div>';
+
+    // ─── コンテンツ ───
+    html += '<div class="ns-card-body">';
+
+    // node 名
+    html += `<div class="ns-card-title">${goal.name}</div>`;
+
     if (isTroy) {
-      html += `<div class="ns-node-hint">最終目標</div>`;
-    } else if (isCleared) {
-      html += `<div class="ns-node-hint">クリア済み</div>`;
+      // TROY：最終目標ロック表示
+      html += '<div class="ns-card-troy-lock"><span>★</span><span class="ns-card-troy-label">最終目標</span></div>';
     } else if (!isUnlocked) {
-      html += `<div class="ns-node-hint">ロック中</div>`;
-    }
-    html += '</div>';
+      // ロック中
+      html += '<div class="ns-card-lock-overlay"><span class="ns-lock-icon">🔒</span><span class="ns-lock-label">ロック中</span></div>';
+    } else {
+      // 出現エネミー（通常 + フラペチーノ）
+      const enemyIds = [...(ch.enemyPool || []), ...(ch.elitePool || [])].slice(0, 4);
+      if (enemyIds.length > 0) {
+        html += '<div class="ns-enemy-row">';
+        enemyIds.forEach(id => {
+          const def = ENEMY_DEFS[id];
+          if (def) {
+            html += `<img class="ns-enemy-img" src="${ENEMY_IMG(def.imgId)}" alt="${def.name}" title="${def.name}" />`;
+          }
+        });
+        html += '</div>';
+      }
 
-    // 矢印（最後の要素以外）
-    if (i < goals.length - 1) {
-      html += '<div class="ns-arrow">→</div>';
+      // ボス
+      const bossDef = ch.bossId ? BOSS_DEFS[ch.bossId] : null;
+      if (bossDef) {
+        html += '<div class="ns-boss-row">';
+        html += '<span class="ns-boss-label">boss</span>';
+        html += `<img class="ns-boss-img" src="${ENEMY_IMG(bossDef.imgId)}" alt="${bossDef.name}" />`;
+        html += `<span class="ns-boss-name">${bossDef.name}</span>`;
+        html += '</div>';
+      }
+
+      // クリア済みバッジ
+      if (isCleared) {
+        html += '<div class="ns-cleared-badge">✓ クリア済み</div>';
+      }
     }
+
+    html += '</div>'; // .ns-card-body
+    html += '</div>'; // .ns-card
   });
 
-  html += '</div>';
+  html += '</div>'; // .ns-cards
   el.innerHTML = html;
 
-  // クリックイベント
-  el.querySelectorAll('.ns-node--unlocked').forEach(nodeEl => {
-    const idx = parseInt(nodeEl.dataset.idx, 10);
+  // クリックイベント（解放済み章のみ）
+  el.querySelectorAll('.ns-card--unlocked, .ns-card--cleared').forEach(cardEl => {
+    const idx = parseInt(cardEl.dataset.idx, 10);
     const activate = () => {
       playSeNodeSelect();
       startRunFromChapter(idx);
     };
-    nodeEl.addEventListener('click', activate);
-    nodeEl.addEventListener('keydown', ev => {
+    cardEl.addEventListener('click', activate);
+    cardEl.addEventListener('keydown', ev => {
       if (ev.key === 'Enter' || ev.key === ' ') activate();
     });
   });
+
+  // 解放アニメ後にクラスを削除
+  if (justUnlockedIdx !== null) {
+    setTimeout(() => {
+      el.querySelector('.ns-card--just-unlocked')?.classList.remove('ns-card--just-unlocked');
+    }, 2000);
+  }
 }
 
 // ─── アセット配線 ─────────────────────────────────────────────────

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -2,6 +2,7 @@ import {
   createCardRuntime,
   shuffle,
   battleIconUrl,
+  CARD_RARITIES,
 } from "./cards.js";
 import {
   img,
@@ -682,6 +683,28 @@ function renderMap() {
     fightImgG.appendChild(imgEl);
   }
   svg.appendChild(fightImgG);
+
+  // ショップ・休憩ノードのアイコン表示
+  const nodeIconG = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  nodeIconG.setAttribute("class", "map-node-icons");
+  for (const node of MAP_NODES) {
+    let iconUrl = null;
+    if (node.type === "shop") iconUrl = img("Image/Icons/gum.png");
+    else if (node.type === "rest") iconUrl = img("Image/BattleIcons/Parameters/hp.png");
+    if (!iconUrl) continue;
+    const sz = 5.2;
+    const iconEl = document.createElementNS("http://www.w3.org/2000/svg", "image");
+    iconEl.setAttribute("href", iconUrl);
+    iconEl.setAttributeNS("http://www.w3.org/1999/xlink", "href", iconUrl);
+    iconEl.setAttribute("x", String(node.x - sz / 2));
+    iconEl.setAttribute("y", String(node.y - sz / 2));
+    iconEl.setAttribute("width", String(sz));
+    iconEl.setAttribute("height", String(sz));
+    iconEl.setAttribute("preserveAspectRatio", "xMidYMid meet");
+    iconEl.setAttribute("class", "map-node-icon-img");
+    nodeIconG.appendChild(iconEl);
+  }
+  svg.appendChild(nodeIconG);
   host.appendChild(svg);
 
   const legend = document.createElement("p");
@@ -1222,8 +1245,10 @@ function renderCombat() {
 
   combat.hand.forEach((card, idx) => {
     const slot = document.createElement("div");
+    const rarity = CARD_RARITIES[card.libraryKey] || 'common';
     slot.className = "card-slot" + (card.cost > combat.energy ? " card-slot--disabled" : "");
     slot.setAttribute("data-cost", String(card.cost));
+    slot.setAttribute("data-rarity", rarity);
     slot.style.setProperty("--i", String(idx + 1));
     slot.style.setProperty("--n", String(Math.max(n - 1, 1)));
 

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -98,6 +98,8 @@ const MAP_START = { id: "START", layer: -1, x: 50, y: 92 };
 // ─── 状態変数 ────────────────────────────────────────────────────
 let gold = 75;
 let view = "map";
+/** セッション内でクリアした章インデックスのセット（node選択画面のアンロック管理） */
+let clearedChapters = new Set();
 /** @type {null | {
  *   chapterIdx: number,
  *   deck: any[],
@@ -146,8 +148,8 @@ function dismissTitle() {
   titleEl.classList.add("title-out");
   setTimeout(() => {
     titleEl.classList.add("hidden");
-    showView("map");
-    renderMap();
+    showView("nodeSelect");
+    renderNodeSelect();
   }, 380);
 }
 
@@ -470,6 +472,8 @@ function ensureRunState() {
 // ─── 章推移 ───────────────────────────────────────────────────────
 function advanceToNextChapter() {
   if (!runState) return;
+  // クリア済み章を記録（node選択画面のアンロックに使用）
+  clearedChapters.add(runState.chapterIdx);
   const nextIdx = runState.chapterIdx + 1;
   if (nextIdx >= CHAPTERS.length) {
     runState.runComplete = true;
@@ -759,14 +763,16 @@ function showView(name) {
   document.getElementById("gameOver").classList.toggle("hidden", name !== "over");
   const rv = document.getElementById("rewardView");
   if (rv) rv.classList.toggle("hidden", name !== "reward");
+  const nsv = document.getElementById("nodeSelectView");
+  if (nsv) nsv.classList.toggle("hidden", name !== "nodeSelect");
   // Show/hide map resources bar
   const mapRes = document.getElementById("mapResources");
   if (mapRes) mapRes.classList.toggle("hidden", name === "combat");
   // Mai navigator: マップビュー内にあるので mapView の hidden に連動
   const nav = document.getElementById("maiNavigator");
   if (nav) nav.classList.toggle("hidden", name !== "map");
-  // マップ BGM: マップ・ショップ・報酬ではBGMを再生（戦闘BGMと重ねない）
-  if (name === "map") startBgmMap();
+  // マップ BGM: マップ・ショップ・報酬・node選択ではBGMを再生
+  if (name === "map" || name === "nodeSelect") startBgmMap();
 }
 
 // ─── 戦闘開始 ─────────────────────────────────────────────────────
@@ -810,6 +816,7 @@ function startCombatFromMapNode(node) {
     deck,
     drawPile: [],
     discardPile: [],
+    exhaustPile: [],
     hand: [],
     playerHp: runState.playerHp,
     playerHpMax: runState.playerHpMax,
@@ -1172,6 +1179,11 @@ function renderCombat() {
   document.getElementById("enemyIntent").textContent = intentText();
   const deckCountEl = document.getElementById("deckPileCount");
   if (deckCountEl) deckCountEl.textContent = String(combat.drawPile.length);
+  // 消耗カード数を表示
+  const exhaustNumEl = document.getElementById("exhaustNum");
+  const exhaustCountEl = document.getElementById("exhaustCount");
+  if (exhaustNumEl) exhaustNumEl.textContent = String(combat.exhaustPile?.length ?? 0);
+  if (exhaustCountEl) exhaustCountEl.dataset.nonzero = (combat.exhaustPile?.length > 0) ? "true" : "false";
 
   // HP gauges
   const playerFill = document.getElementById("playerHpFill");
@@ -1211,8 +1223,8 @@ function renderCombat() {
 
     slot.innerHTML =
       '<div class="card-cost-above"><span class="cost-zeus" aria-hidden="true">⚡</span>' + card.cost + '</div>' +
-      '<div class="card ' + card.type + '">' +
-      '<div class="card-name-hd">' + escapeHtml(card.extNameJa) + '</div>' +
+      '<div class="card ' + card.type + (card.exhaust ? ' card--exhaust' : '') + '">' +
+      '<div class="card-name-hd">' + escapeHtml(card.extNameJa) + (card.exhaust ? '<span class="exhaust-badge" title="消耗：使い切り">🔥</span>' : '') + '</div>' +
       '<div class="card-icon-area">' +
       '<img class="card-ext-img-full" src="' + EXT_IMG(card.extId) + '" alt="" />' +
       '<img class="card-skill-icon-tl" src="' + battleIconUrl(card.skillIcon) + '" alt="" />' +
@@ -1245,7 +1257,13 @@ function playCard(idx) {
   if (!card || card.cost > combat.energy) return;
   combat.energy -= card.cost;
   combat.hand.splice(idx, 1);
-  combat.discardPile.push(card);
+  // 消耗カードは exhaustPile へ、通常カードは捨て札へ
+  if (card.exhaust) {
+    combat.exhaustPile.push(card);
+    clog(`【消耗】${card.extNameJa} を除外`);
+  } else {
+    combat.discardPile.push(card);
+  }
   card.play(combat);
   if (combat.enemyHp <= 0) { endCombatWin(); return; }
   renderCombat();
@@ -1567,8 +1585,94 @@ function resetRun() {
   postCombatSnapshot = null;
   stopBgm();
   dismissCutin();
+  showView("nodeSelect");
+  renderNodeSelect();
+}
+
+// ─── Node 選択画面 ────────────────────────────────────────────────
+/**
+ * 指定した章インデックスからランを開始する。
+ * clearedChapters に前の章が含まれている（またはインデックス 0）場合のみ呼び出し可。
+ */
+function startRunFromChapter(chapterIdx) {
+  gold = 75;
+  combat = null;
+  pendingShopNodeId = null;
+  postCombatSnapshot = null;
+  const chapter = CHAPTERS[chapterIdx];
+  const { nodes, edges } = generateChapterMap(chapter, ENEMY_DEFS);
+  setActiveMap(nodes, edges);
+  runState = {
+    chapterIdx,
+    deck: makeStarterDeck(),
+    playerHp: LEADER.hpMax,
+    playerHpMax: LEADER.hpMax,
+    lastMapNodeId: null,
+    pathNodeIds: [],
+    runComplete: false,
+  };
   showView("map");
   renderMap();
+}
+
+/** node 選択画面を描画する */
+function renderNodeSelect() {
+  const el = document.getElementById("nodeSelectView");
+  if (!el) return;
+
+  // CHAPTERS + ゴール「TROY」の構成
+  const goals = [
+    ...CHAPTERS.map((ch, idx) => ({ idx, name: ch.name.replace('node : ', ''), chapter: ch })),
+    { idx: CHAPTERS.length, name: 'TROY', chapter: null },
+  ];
+
+  let html = '<div class="ns-header"><h2>node を選択してください</h2><p class="ns-sub">ボスを倒すと次の node が解放されます</p></div>';
+  html += '<div class="ns-path">';
+
+  goals.forEach((goal, i) => {
+    const isLast = i === goals.length - 1; // TROY
+    const isUnlocked = goal.idx === 0 || clearedChapters.has(goal.idx - 1);
+    const isCleared  = clearedChapters.has(goal.idx);
+    const isTroy     = isLast;
+
+    let stateClass = isTroy ? 'ns-node--troy' :
+                     isCleared  ? 'ns-node--cleared' :
+                     isUnlocked ? 'ns-node--unlocked' :
+                                  'ns-node--locked';
+
+    html += `<div class="ns-node ${stateClass}" data-idx="${goal.idx}" role="button" tabindex="${isUnlocked && !isTroy ? 0 : -1}">`;
+    html += `<div class="ns-node-icon">${isCleared ? '✓' : isTroy ? '★' : isUnlocked ? '▶' : '🔒'}</div>`;
+    html += `<div class="ns-node-name">${goal.name}</div>`;
+    if (isTroy) {
+      html += `<div class="ns-node-hint">最終目標</div>`;
+    } else if (isCleared) {
+      html += `<div class="ns-node-hint">クリア済み</div>`;
+    } else if (!isUnlocked) {
+      html += `<div class="ns-node-hint">ロック中</div>`;
+    }
+    html += '</div>';
+
+    // 矢印（最後の要素以外）
+    if (i < goals.length - 1) {
+      html += '<div class="ns-arrow">→</div>';
+    }
+  });
+
+  html += '</div>';
+  el.innerHTML = html;
+
+  // クリックイベント
+  el.querySelectorAll('.ns-node--unlocked').forEach(nodeEl => {
+    const idx = parseInt(nodeEl.dataset.idx, 10);
+    const activate = () => {
+      playSeNodeSelect();
+      startRunFromChapter(idx);
+    };
+    nodeEl.addEventListener('click', activate);
+    nodeEl.addEventListener('keydown', ev => {
+      if (ev.key === 'Enter' || ev.key === ' ') activate();
+    });
+  });
 }
 
 // ─── アセット配線 ─────────────────────────────────────────────────
@@ -1660,8 +1764,8 @@ function init() {
       if (ev.key === "Enter" || ev.key === " ") dismissTitle();
     });
   }
-  // マップ側は非表示で待機（タイトルが覆うので見えない）
-  showView("map"); // 内部状態はマップに初期化
+  // nodeSelect を非表示で待機（タイトルが覆うので見えない）
+  showView("nodeSelect"); // 内部状態は nodeSelect に初期化
   // BGM はタイトルクリック時に開始（ブラウザのオートプレイ制限のため init では呼ばない）
 }
 


### PR DESCRIPTION
## Summary

- **node選択画面** をタイトルとマップ画面の間に追加。アバカス→ホレリス→アンティキティラ→アタナソフ→TROY（ロック）のルートを表示し、前章クリアで次章が解放される
- **ホレリス章**（章2）を新規追加。敵3種・フラペチーノ1種・ボス（ゴースト・ビスマルク）・カード6種
- **消耗（Exhaust）カードメカニクス** を実装。`exhaust:true` カードは使用後に `exhaustPile` へ移動しデッキに戻らない（🔥バッジで識別）
- **ダメージ/バフ浮き数字を大型化**（0.95rem → 1.8rem）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `enemies.js` | hl-001/002/003/e01 追加 |
| `bosses.js` | boss-hl（ゴースト・ビスマルク）追加 |
| `chapters.js` | 章順変更（ホレリス挿入）+ ホレリス定義追加 |
| `cards.js` | cdH01〜cdH06 追加（内2枚が exhaust:true）|
| `main.js` | clearedChapters Set・startRunFromChapter・renderNodeSelect・exhaustPile 対応 |
| `index.html` | nodeSelectView HTML/CSS・exhaust表示・stat-float 拡大 |

## Test plan

- [ ] タイトル画面をタップ → node選択画面が表示される
- [ ] アバカスのみ選択可能（▶表示）、ホレリス以降は🔒
- [ ] アバカスを選択 → マップ画面へ遷移してゲーム開始
- [ ] アバカスのボスを倒す → 「もう一度」でnode選択に戻り、ホレリスが解放される
- [ ] ホレリスの敵3種・フラペチーノ・ゴースト・ビスマルクが正しく出現する
- [ ] cdH01（エリートカタナ、消耗）使用後にデッキに戻らず🔥カウントが増える
- [ ] cdH04（エリートペン、消耗）同様に消耗動作確認
- [ ] 戦闘フッターに🔥消耗済み枚数が正しく表示される
- [ ] ダメージ浮き数字が大きく表示される

## 受け入れ基準チェック

- [x] タイトル→node選択→マップ フロー
- [x] セッション内アンロック（clearedChapters）
- [x] TROY がロック状態で表示される
- [x] ホレリス章のデータが全種定義済み
- [x] exhaust カードが捨て札に戻らない
- [x] stat-float 拡大

🤖 Generated with [Claude Code](https://claude.com/claude-code)