### PR TITLE
fix(shop): カード破棄を 1 ショップ訪問につき 1 枚までに制限 (#33)

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1590,6 +1590,12 @@
       border-color: var(--danger); color: #ff8090;
     }
     .shop-remove-btn:hover { background: #3a1828; }
+    .shop-remove-btn.sold-out,
+    .shop-remove-btn.sold-out:hover {
+      background: #1a1518; color: var(--muted);
+      border-color: var(--border); cursor: not-allowed;
+      opacity: 0.65;
+    }
     /* Remove card overlay */
     .shop-remove-overlay {
       position: fixed; inset: 0;

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -2428,6 +2428,9 @@ function openShop() {
   });
 
   // ─── カード破棄セクション ──────────────────────────────────────
+  // ショップ訪問のたびに 1 回までに制限 (#33) — 入店時にフラグ初期化
+  runState.shopRemoveUsed = false;
+
   const removeSection = document.createElement("div");
   removeSection.className = "shop-remove-section";
   const removeTitle = document.createElement("div");
@@ -2436,14 +2439,14 @@ function openShop() {
   removeSection.appendChild(removeTitle);
   const removeDesc = document.createElement("div");
   removeDesc.className = "shop-remove-desc";
-  removeDesc.textContent = "デッキ内のカードを1枚選んで除外できます（スターターも含む）。";
+  removeDesc.textContent = "デッキ内のカードを1枚選んで除外できます（スターターも含む）。1 ショップ訪問につき 1 枚まで。";
   removeSection.appendChild(removeDesc);
 
   const removeBtn = document.createElement("button");
   removeBtn.type = "button";
   removeBtn.className = "shop-remove-btn action";
   removeBtn.textContent = "カードを破棄する";
-  removeBtn.addEventListener("click", () => openShopRemoveCard(goldDisp));
+  removeBtn.addEventListener("click", () => openShopRemoveCard(goldDisp, removeBtn));
   removeSection.appendChild(removeBtn);
   list.parentElement.appendChild(removeSection);
 
@@ -2453,8 +2456,19 @@ function openShop() {
 
 // ─── ショップ カード破棄 ──────────────────────────────────────────
 const SHOP_REMOVE_COST = 50;
-function openShopRemoveCard(goldDisp) {
+function setShopRemoveBtnSoldOut(btn) {
+  if (!btn) return;
+  btn.disabled = true;
+  btn.classList.add("sold-out");
+  btn.textContent = "売り切れ（このショップでは使用済み）";
+}
+function openShopRemoveCard(goldDisp, removeBtn) {
   ensureRunState();
+  if (runState.shopRemoveUsed) {
+    renderNavigator("このショップではすでにカード破棄を 1 回使用しています");
+    setShopRemoveBtnSoldOut(removeBtn);
+    return;
+  }
   if (gold < SHOP_REMOVE_COST) {
     renderNavigator(`GUM が足りません（必要: ${SHOP_REMOVE_COST} GUM）`);
     return;
@@ -2510,6 +2524,9 @@ function openShopRemoveCard(goldDisp) {
       syncResources();
       clog(`破棄: ${card.extNameJa}（-${SHOP_REMOVE_COST} GUM）`);
       renderNavigator(`「${card.extNameJa}」を破棄しました！デッキが軽くなりましたよ！`);
+      // 1 ショップ訪問につき 1 回まで (#33)
+      runState.shopRemoveUsed = true;
+      setShopRemoveBtnSoldOut(removeBtn);
       overlay.remove();
     });
     wrapper.appendChild(delBtn);


### PR DESCRIPTION
## Summary
GUM さえあればショップで何枚もカード破棄できて強すぎた問題を修正。
1 回のショップ訪問につき 1 枚まで（使用すると売り切れ扱い）に制限。

## 仕様
- ショップ入店ごとに `runState.shopRemoveUsed = false` にリセット
- 破棄成功 → `runState.shopRemoveUsed = true` + ボタンを「売り切れ（このショップでは使用済み）」表示 + disabled
- 別の shop node に入ると再度 1 回使える
- 死亡 / 「もう一度」で完全リセット（既存 resetRun 経由）

## 変更内容
- `prototype/js/main.js`:
  - `openShop()` でフラグ初期化
  - `openShopRemoveCard(goldDisp, removeBtn)` に removeBtn を引数化
  - フラグチェック + `setShopRemoveBtnSoldOut()` ヘルパー追加
  - 破棄成功時にフラグ立て + ボタン無効化
- `prototype/index.html`:
  - `.shop-remove-btn.sold-out` スタイル追加（暗色 + cursor: not-allowed）
- 説明文に「1 ショップ訪問につき 1 枚まで」を明記

## Test plan
- [ ] ショップ入店 → 破棄 1 回成功 → ボタンが「売り切れ」表示で押せない
- [ ] ショップを出て次の shop node に入る → 再度 1 回使える
- [ ] GUM 不足時の挙動（変更なし）
- [ ] デッキが空の時の挙動（変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)