### PR TITLE
feat(release): Vercel Analytics + X シェア #タグ + README ライセンス (#24, #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,21 @@
 
 ## クレジット・ライセンス
 
+### アセット（画像・BGM・SE）
+
 キャラクター画像・エクステンション画像・BGM / SE は [bearko/mycryptoheroes](https://github.com/bearko/mycryptoheroes) の素材を使用しています。これらのアセットは **My Crypto Heroes (MCH Co., Ltd.)** に帰属し、ファンが作成した二次創作コンテンツとして利用しています。商用利用は行っていません。
 
-ゲームのソースコード (`.js`, `.html`, `.css`) は MIT ライセンスです。アセット（画像・音声）のライセンスは MCH の利用ガイドラインに従ってください。
+アセットの利用条件・ガイドラインは MCH 公式の方針に準じます。詳細はこちらを参照してください:
+
+**▶ [bearko/mycryptoheroes — README（アセット利用ガイドライン）](https://github.com/bearko/mycryptoheroes/blob/main/README.md)**
+
+二次創作 / アセット利用に関する問い合わせは MCH 公式または上記リポジトリへお願いします。
+
+### ソースコード
+
+ゲームのソースコード (`prototype/js/`, `prototype/index.html`, `prototype/sim/` 等) は MIT ライセンスです。フォーク・改変・再配布は自由です。
+
+ただしアセット（画像・音声）は上記の通り **MCH のガイドライン準拠** であり、ソースコードのライセンスとは別管轄である点に注意してください。
 
 ---
 

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -2304,5 +2304,12 @@
   </div>
 
   <script type="module" src="./js/main.js"></script>
+
+  <!-- Vercel Web Analytics (#24): Vercel ホスティング上で自動的に /_vercel/insights/script.js が配信される。
+       ローカルや非 Vercel 環境では 404 となるが、無視されてゲーム動作には影響しない。 -->
+  <script>
+    window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+  </script>
+  <script defer src="/_vercel/insights/script.js"></script>
 </body>
 </html>

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -2315,8 +2315,13 @@ function showActivityReport(snap) {
       const intro = snap.isCleared
         ? `${snap.hero.name} で全ステージ制覇しました！`
         : `${snap.hero.name} で「${snap.stageName}」まで到達。${snap.opponent.name} に倒された…`;
-      const text = `${intro} #${SHARE_TITLE}`;
-      const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(SHARE_URL)}`;
+      // Twitter Web Intent: text / url / hashtags を分けて渡すと自然に組み立てられる。
+      // hashtags はカンマ区切りで # なし。`#MyCryptoTactics` が末尾に付く。
+      const url =
+        `https://twitter.com/intent/tweet` +
+        `?text=${encodeURIComponent(intro)}` +
+        `&url=${encodeURIComponent(SHARE_URL)}` +
+        `&hashtags=${encodeURIComponent(SHARE_TITLE)}`;
       window.open(url, "_blank", "noopener,noreferrer");
     });
   });


### PR DESCRIPTION
## Summary
α版リリース準備の 3 件:

### #24 フィードバック収集 — 最小実装
- **Vercel Web Analytics** を有効化（index.html 末尾に script タグ追加）
- 活動レポートの **X シェアを hashtags パラメータ化** → `#MyCryptoTactics` で投稿を追跡可能

### #25 リリースチェックリスト消化
- **README ライセンス節を再構成**
  - アセット / ソースコード を明確に分離
  - アセット利用ガイドラインへのリンク明示（[bearko/mycryptoheroes](https://github.com/bearko/mycryptoheroes/blob/main/README.md)）

## Vercel ダッシュボード側で必要な作業（コード以外）
1. https://vercel.com/dashboard → mycryptotactics プロジェクト → **Analytics** タブを開く
2. 「Enable Analytics」ボタンをクリック
3. 数分後、PV / 流入元 / デバイス等のデータが見られるようになる

※ Pro プランでない場合、データの保持期間や数に制限あり。α 版規模なら無料枠で十分。

## X シェア URL の変化
- **before**: `?text=甲斐姫 で...！ %23MyCryptoTactics&url=https://...`
- **after**: `?text=甲斐姫 で...！&url=https://...&hashtags=MyCryptoTactics`

機能差分なし、ハッシュタグが Twitter UI で見やすい位置に表示される。

## Test plan
- [ ] Vercel Analytics タブを Enable し、本番でアクセス → ダッシュボードに数分以内にデータが出る
- [ ] 活動レポート → X シェア → 投稿画面に「#MyCryptoTactics」が含まれている
- [ ] README のリンクが正しく [bearko/mycryptoheroes](https://github.com/bearko/mycryptoheroes/blob/main/README.md) を指す

## 関連 Issue
- #24 フィードバック収集
- #25 リリースチェックリスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)