### PR TITLE
feat(regulation): 5 段階レギュレーション機能 + 活動レポート名前ソート (#36, #37)

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1292,8 +1292,12 @@
     }
 
     /* ── Header Regulation Icon (#37) ────────────────────────── */
-    /* 横長カップ画像のアスペクト比を活かすため横幅を 3 倍に */
-    .header-reg-icon {
+    /* 横長カップ画像のアスペクト比を活かすため横幅を 3 倍に。
+       .resources img の generic 指定 (22×22) を上書きするため
+       両ヘッダー context での指定で specificity を確保。 */
+    .header-reg-icon,
+    .resources img.header-reg-icon,
+    .combat-header-btns img.header-reg-icon {
       width: 84px; height: 28px;
       object-fit: contain; image-rendering: pixelated;
       vertical-align: middle;
@@ -1302,7 +1306,11 @@
       padding: 1px 3px;
     }
     @media (max-width: 380px) {
-      .header-reg-icon { width: 64px; height: 24px; }
+      .header-reg-icon,
+      .resources img.header-reg-icon,
+      .combat-header-btns img.header-reg-icon {
+        width: 64px; height: 24px;
+      }
     }
 
     .hs-header { text-align: center; margin-bottom: 1.2rem; }

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1229,6 +1229,66 @@
       width: 100%; max-width: 900px;
       padding: 1.2rem 0.75rem 2rem;
     }
+    /* ── Regulation Select (#37) ────────────────────────────── */
+    #regulationSelectView {
+      padding: 1.2rem 0.75rem 2rem;
+    }
+    .rs-header { text-align: center; margin-bottom: 1.2rem; }
+    .rs-header h2 { margin: 0 0 0.3rem; font-size: 1.2rem; color: var(--accent); }
+    .rs-sub { margin: 0; font-size: 0.78rem; color: var(--muted); }
+    .rs-list {
+      display: flex; flex-wrap: wrap; justify-content: center;
+      gap: 0.7rem;
+    }
+    .rs-card {
+      width: 168px;
+      background: var(--panel);
+      border: 2px solid var(--border);
+      border-radius: 12px;
+      padding: 0.75rem 0.6rem 0.85rem;
+      display: flex; flex-direction: column; align-items: center;
+      gap: 0.5rem;
+      transition: border-color 0.15s, transform 0.15s;
+    }
+    .rs-card--unlocked { cursor: pointer; }
+    .rs-card--unlocked:hover { border-color: var(--accent); transform: translateY(-2px); }
+    .rs-card--current { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(253,203,110,0.25); }
+    .rs-card--locked { opacity: 0.55; }
+    .rs-card-cup {
+      position: relative; width: 96px; height: 96px;
+      display: flex; align-items: center; justify-content: center;
+      background: radial-gradient(ellipse at center, #1a1530 0%, #0a0712 80%);
+      border-radius: 12px;
+    }
+    .rs-card-cup img {
+      width: 80px; height: 80px;
+      object-fit: contain;
+      image-rendering: pixelated;
+    }
+    .rs-lock {
+      position: absolute; inset: 0;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 2rem;
+      background: rgba(0,0,0,0.55);
+      border-radius: 12px;
+    }
+    .rs-card-body { width: 100%; text-align: center; display: flex; flex-direction: column; gap: 0.45rem; }
+    .rs-card-name { font-weight: 800; font-size: 0.95rem; letter-spacing: 0.04em; }
+    .rs-card-desc { font-size: 0.7rem; color: var(--muted); line-height: 1.35; min-height: 2.6em; }
+    .rs-select-btn { font-size: 0.75rem; padding: 0.4rem 0.5rem; }
+    .rs-select-btn--current { background: var(--accent); color: #2c1810; cursor: default; }
+    .rs-locked-hint { font-size: 0.7rem; color: var(--muted); }
+
+    /* ── Header Regulation Icon (#37) ────────────────────────── */
+    .header-reg-icon {
+      width: 28px; height: 28px;
+      object-fit: contain; image-rendering: pixelated;
+      vertical-align: middle;
+      border-radius: 4px;
+      background: #15121c;
+      padding: 1px;
+    }
+
     .hs-header { text-align: center; margin-bottom: 1.2rem; }
     .hs-header h2 { margin: 0 0 0.3rem; font-size: 1.2rem; color: var(--accent); }
     .hs-sub { margin: 0; font-size: 0.78rem; color: var(--muted); }
@@ -1547,9 +1607,39 @@
       color: var(--text); line-height: 1.2;
     }
     .report-stage {
-      text-align: center; margin: 0.2rem 0 0.7rem;
+      text-align: center; margin: 0.2rem 0 0.4rem;
       font-size: 0.85rem; font-weight: 700; color: #FDCB6E;
       letter-spacing: 0.04em;
+    }
+    .report-regulation {
+      display: flex; align-items: center; justify-content: center;
+      gap: 0.4rem; margin: 0.1rem 0 0.6rem;
+      font-size: 0.78rem; color: var(--text);
+    }
+    .report-regulation img {
+      width: 24px; height: 24px;
+      object-fit: contain; image-rendering: pixelated;
+      background: #15121c; border-radius: 4px; padding: 1px;
+    }
+    .report-unlock {
+      display: flex; align-items: center; justify-content: center;
+      gap: 0.45rem;
+      margin: 0 0 0.7rem; padding: 0.45rem 0.5rem;
+      background: linear-gradient(90deg, rgba(253,203,110,0.15), rgba(255,82,82,0.15));
+      border: 1px solid #FDCB6E; border-radius: 8px;
+      font-size: 0.78rem; font-weight: 700; color: #FDCB6E;
+      animation: pulse-unlock 1.6s ease-in-out infinite;
+    }
+    .report-unlock.hidden { display: none; }
+    .report-unlock-flair { font-size: 0.7rem; letter-spacing: 0.06em; }
+    .report-unlock img {
+      width: 28px; height: 28px;
+      object-fit: contain; image-rendering: pixelated;
+      background: rgba(0,0,0,0.4); border-radius: 4px; padding: 1px;
+    }
+    @keyframes pulse-unlock {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(253,203,110,0.0); }
+      50%      { box-shadow: 0 0 12px 2px rgba(253,203,110,0.35); }
     }
     .report-section { margin: 0.65rem 0; }
     .report-ext-grid {
@@ -1934,6 +2024,7 @@
         <span class="ll-ext-slot-icon" id="mapLlSlot1" title="">—</span>
       </span>
       <button type="button" class="btn-deck-view" id="btnDeckViewMap" aria-label="保有デッキを表示" title="保有デッキを表示"><span class="btn-deck-view-icon">📚</span><span class="btn-deck-view-label">デッキ表示</span></button>
+      <img class="header-reg-icon" id="headerRegIconMap" alt="レギュレーション" title="レギュレーション" />
       <button type="button" class="btn-help" id="btnHelpOpen" aria-label="ヘルプを開く" title="ヘルプ">?</button>
     </div>
 
@@ -1967,6 +2058,7 @@
         <span class="combat-header-stage" id="combatStageTitle">—</span>
         <div class="combat-header-btns">
           <button type="button" class="btn-deck-view btn-deck-view-combat" id="btnDeckViewCombat" aria-label="保有デッキを表示" title="保有デッキを表示"><span class="btn-deck-view-icon">📚</span><span class="btn-deck-view-label">デッキ表示</span></button>
+          <img class="header-reg-icon" id="headerRegIconCombat" alt="レギュレーション" title="レギュレーション" />
           <button type="button" class="btn-icon-hd" id="btnSettingsOpen" aria-label="設定" title="設定">⚙</button>
           <button type="button" class="btn-icon-hd" id="btnHelpOpenCombat" aria-label="ヘルプ" title="ヘルプ">?</button>
         </div>
@@ -2093,6 +2185,8 @@
 
     </div>
 
+    <div id="regulationSelectView" class="hidden"></div>
+
     <div id="heroSelectView" class="hidden"></div>
 
     <div id="nodeSelectView" class="hidden"></div>
@@ -2161,6 +2255,17 @@
       </div>
 
       <p class="report-stage" id="reportStage"></p>
+
+      <div class="report-regulation" id="reportRegulation">
+        <img id="reportRegIcon" alt="" onerror="this.style.opacity='0'" />
+        <span id="reportRegName"></span>
+      </div>
+
+      <div class="report-unlock hidden" id="reportUnlock">
+        <span class="report-unlock-flair">★ NEW UNLOCK ★</span>
+        <img id="reportUnlockIcon" alt="" onerror="this.style.opacity='0'" />
+        <span id="reportUnlockName"></span>
+      </div>
 
       <div class="report-section">
         <p class="report-block-label">保有エクステンション <span id="reportDeckCount" class="report-block-count"></span></p>

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1237,56 +1237,72 @@
     .rs-header h2 { margin: 0 0 0.3rem; font-size: 1.2rem; color: var(--accent); }
     .rs-sub { margin: 0; font-size: 0.78rem; color: var(--muted); }
     .rs-list {
-      display: flex; flex-wrap: wrap; justify-content: center;
-      gap: 0.7rem;
+      display: flex; flex-direction: column;
+      gap: 0.6rem;
+      max-width: 560px; margin: 0 auto;
     }
     .rs-card {
-      width: 168px;
+      width: 100%;
       background: var(--panel);
       border: 2px solid var(--border);
       border-radius: 12px;
-      padding: 0.75rem 0.6rem 0.85rem;
-      display: flex; flex-direction: column; align-items: center;
-      gap: 0.5rem;
+      padding: 0.55rem 0.7rem;
+      display: grid;
+      grid-template-columns: minmax(180px, 38%) 1fr;
+      align-items: center;
+      gap: 0.7rem;
       transition: border-color 0.15s, transform 0.15s;
     }
     .rs-card--unlocked { cursor: pointer; }
-    .rs-card--unlocked:hover { border-color: var(--accent); transform: translateY(-2px); }
+    .rs-card--unlocked:hover { border-color: var(--accent); transform: translateX(2px); }
     .rs-card--current { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(253,203,110,0.25); }
     .rs-card--locked { opacity: 0.55; }
     .rs-card-cup {
-      position: relative; width: 96px; height: 96px;
+      position: relative;
+      width: 100%; aspect-ratio: 16 / 6;
       display: flex; align-items: center; justify-content: center;
-      background: radial-gradient(ellipse at center, #1a1530 0%, #0a0712 80%);
-      border-radius: 12px;
+      background: radial-gradient(ellipse at center, #1a1530 0%, #0a0712 85%);
+      border-radius: 8px;
+      overflow: hidden;
     }
     .rs-card-cup img {
-      width: 80px; height: 80px;
+      width: 100%; height: 100%;
       object-fit: contain;
       image-rendering: pixelated;
     }
     .rs-lock {
       position: absolute; inset: 0;
       display: flex; align-items: center; justify-content: center;
-      font-size: 2rem;
+      font-size: 1.6rem;
       background: rgba(0,0,0,0.55);
-      border-radius: 12px;
+      border-radius: 8px;
     }
-    .rs-card-body { width: 100%; text-align: center; display: flex; flex-direction: column; gap: 0.45rem; }
+    .rs-card-body {
+      display: flex; flex-direction: column; gap: 0.35rem;
+      min-width: 0;
+    }
     .rs-card-name { font-weight: 800; font-size: 0.95rem; letter-spacing: 0.04em; }
-    .rs-card-desc { font-size: 0.7rem; color: var(--muted); line-height: 1.35; min-height: 2.6em; }
-    .rs-select-btn { font-size: 0.75rem; padding: 0.4rem 0.5rem; }
+    .rs-card-desc { font-size: 0.72rem; color: var(--muted); line-height: 1.4; }
+    .rs-select-btn { font-size: 0.75rem; padding: 0.4rem 0.6rem; align-self: flex-start; }
     .rs-select-btn--current { background: var(--accent); color: #2c1810; cursor: default; }
     .rs-locked-hint { font-size: 0.7rem; color: var(--muted); }
+    @media (max-width: 480px) {
+      .rs-card { grid-template-columns: 36% 1fr; padding: 0.5rem; gap: 0.5rem; }
+      .rs-card-cup { aspect-ratio: 16 / 7; }
+    }
 
     /* ── Header Regulation Icon (#37) ────────────────────────── */
+    /* 横長カップ画像のアスペクト比を活かすため横幅を 3 倍に */
     .header-reg-icon {
-      width: 28px; height: 28px;
+      width: 84px; height: 28px;
       object-fit: contain; image-rendering: pixelated;
       vertical-align: middle;
       border-radius: 4px;
       background: #15121c;
-      padding: 1px;
+      padding: 1px 3px;
+    }
+    @media (max-width: 380px) {
+      .header-reg-icon { width: 64px; height: 24px; }
     }
 
     .hs-header { text-align: center; margin-bottom: 1.2rem; }

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -33,6 +33,26 @@ import { BOSS_DEFS } from "./bosses.js";
 import { CHAPTERS } from "./chapters.js";
 import { generateChapterMap } from "./maps.js";
 import { LL_EXT_POOL } from "./ll-extensions.js";
+import {
+  REGULATIONS,
+  REGULATION_BY_ID,
+  loadUnlockedRegulations,
+  loadCurrentRegulationId,
+  saveCurrentRegulationId,
+  unlockNextAfterClear,
+} from "./regulations.js";
+
+// 現在選択中のレギュレーション (#37) — 全戦闘・全画面でこの値を参照
+let currentRegulationId = loadCurrentRegulationId();
+function getCurrentRegulation() {
+  return REGULATION_BY_ID[currentRegulationId] || REGULATIONS[0];
+}
+function setCurrentRegulation(id) {
+  if (!REGULATION_BY_ID[id]) return;
+  currentRegulationId = id;
+  saveCurrentRegulationId(id);
+  updateHeaderRegulationIcons();
+}
 
 // ─── ナビゲーター「マイ」 ────────────────────────────────────────
 const MAI_SD_URL = "./MAI_SD.png";
@@ -161,8 +181,9 @@ function dismissTitle() {
   titleEl.classList.add("title-out");
   setTimeout(() => {
     titleEl.classList.add("hidden");
-    showView("heroSelect");
-    renderHeroSelect();
+    // タイトル → レギュレーション選択 → ヒーロー選択 (#37)
+    showView("regulationSelect");
+    renderRegulationSelect();
   }, 380);
 }
 
@@ -823,6 +844,13 @@ function advanceToNextChapter() {
   if (nextIdx >= CHAPTERS.length) {
     runState.runComplete = true;
     playSeClear();
+    // レギュレーション解放 (#37): 全章クリア → 次のレギュレーションをアンロック
+    const newlyUnlocked = unlockNextAfterClear(currentRegulationId);
+    if (newlyUnlocked) {
+      const r = REGULATION_BY_ID[newlyUnlocked];
+      clog(`★ レギュレーション「${r.nameJa}」が解放されました！`);
+      runState.unlockedRegulationOnClear = newlyUnlocked;
+    }
     return;
   }
   runState.chapterIdx = nextIdx;
@@ -1158,14 +1186,16 @@ function showView(name) {
   if (cv) cv.classList.toggle("hidden", name !== "craft");
   const hsv = document.getElementById("heroSelectView");
   if (hsv) hsv.classList.toggle("hidden", name !== "heroSelect");
-  // Show/hide map resources bar（ヒーロー選択・戦闘中は非表示）
+  const rsv = document.getElementById("regulationSelectView");
+  if (rsv) rsv.classList.toggle("hidden", name !== "regulationSelect");
+  // Show/hide map resources bar（ヒーロー選択・レギュレーション選択・戦闘中は非表示）
   const mapRes = document.getElementById("mapResources");
-  if (mapRes) mapRes.classList.toggle("hidden", name === "combat" || name === "heroSelect");
+  if (mapRes) mapRes.classList.toggle("hidden", name === "combat" || name === "heroSelect" || name === "regulationSelect");
   // Mai navigator: マップビュー内にあるので mapView の hidden に連動
   const nav = document.getElementById("maiNavigator");
   if (nav) nav.classList.toggle("hidden", name !== "map");
-  // マップ BGM: マップ・ショップ・報酬・node選択・ヒーロー選択ではBGMを再生
-  if (name === "map" || name === "nodeSelect" || name === "heroSelect") startBgmMap();
+  // マップ BGM: マップ・ショップ・報酬・node選択・ヒーロー選択・レギュレーション選択ではBGMを再生
+  if (name === "map" || name === "nodeSelect" || name === "heroSelect" || name === "regulationSelect") startBgmMap();
 }
 
 // ─── 戦闘開始 ─────────────────────────────────────────────────────
@@ -1205,6 +1235,12 @@ function startCombatFromMapNode(node) {
     intentRota = enemyDef.intentRota;
   }
 
+  // レギュレーション効果適用 (#37)
+  const reg = getCurrentRegulation();
+  const regHp = Math.max(1, Math.round(enemyDef.hp * reg.effects.hpFactor));
+  const regPhy = Math.max(1, Math.round(enemyDef.phy * reg.effects.atkFactor));
+  const regInt = Math.max(1, Math.round(enemyDef.int * reg.effects.atkFactor));
+
   combat = {
     deck,
     drawPile: [],
@@ -1224,10 +1260,10 @@ function startCombatFromMapNode(node) {
     bonusEnergyNext: 0,
     phyPenaltyNext: 0,
     damageReducedThisTurn: false,
-    enemyHp: enemyDef.hp,
-    enemyHpMax: enemyDef.hp,
-    enemyPhy: enemyDef.phy, enemyInt: enemyDef.int, enemyAgi: enemyDef.agi,
-    enemyPhyBase: enemyDef.phy, enemyIntBase: enemyDef.int, enemyAgiBase: enemyDef.agi,
+    enemyHp: regHp,
+    enemyHpMax: regHp,
+    enemyPhy: regPhy, enemyInt: regInt, enemyAgi: enemyDef.agi,
+    enemyPhyBase: regPhy, enemyIntBase: regInt, enemyAgiBase: enemyDef.agi,
     enemyGuard: 0,
     enemyShield: enemyDef.initialShield || 0,
     enemyPoison: 0,
@@ -1793,6 +1829,17 @@ async function enemyTurn() {
   const it = combat.enemyIntent;
   if (!it) { combat.turn++; startPlayerTurn(); return; }
 
+  // レギュレーション効果: 毎ターン初期ガード付与（Blue+） (#37)
+  const reg = getCurrentRegulation();
+  if (reg.effects.guardPerTurn > 0) {
+    combat.enemyGuard += reg.effects.guardPerTurn;
+    clog(`敵 GUARD +${reg.effects.guardPerTurn}（${reg.nameJa} 効果）`);
+  }
+
+  // レギュレーション効果: 攻撃に出血付与（Red+） (#37)
+  const isAttackKind = it.kind && it.kind.startsWith && it.kind.startsWith("attack");
+  const regBleedStacks = reg.effects.bleedOnAttack || 0;
+
   switch (it.kind) {
     case "attack":
       dealPhySkillFromEnemyToPlayer(combat, it.phyPct);
@@ -1847,6 +1894,14 @@ async function enemyTurn() {
       break;
     default:
       clog(`不明な意図: ${it.kind}`);
+  }
+
+  // レギュレーション効果: 攻撃に出血付与（Red+） (#37)
+  if (isAttackKind && regBleedStacks > 0 && combat.playerHp > 0) {
+    combat.playerBleed = (combat.playerBleed || 0) + regBleedStacks;
+    playBattleSe("debuff");
+    clog(`出血 ×${regBleedStacks} 付与（自分・${reg.nameJa} 効果）`);
+    renderStatusBadges();
   }
 
   if (combat.playerHp <= 0) { endCombatLoss(); return; }
@@ -2211,16 +2266,27 @@ function captureRunSnapshot({ isCleared, defeatedBy }) {
   if (!runState || !LEADER) return null;
   const chapter = CHAPTERS[runState.chapterIdx] || null;
   const stageName = chapter ? chapter.name : "";
+  const reg = getCurrentRegulation();
+  const newlyUnlocked = isCleared && runState.unlockedRegulationOnClear
+    ? REGULATION_BY_ID[runState.unlockedRegulationOnClear]
+    : null;
   return {
     isCleared,
     when: new Date(),
     hero: { name: LEADER.nameJa, imgUrl: LEADER.img() },
+    regulation: { id: reg.id, name: reg.nameJa, iconUrl: reg.iconUrl, color: reg.color },
+    newlyUnlockedRegulation: newlyUnlocked
+      ? { id: newlyUnlocked.id, name: newlyUnlocked.nameJa, iconUrl: newlyUnlocked.iconUrl }
+      : null,
     stageName,
-    deck: (runState.deck || []).map((c) => ({
-      libraryKey: c.libraryKey,
-      extId: c.extId,
-      extNameJa: c.extNameJa,
-    })),
+    // #36 名前順ソート（同シリーズが隣同士に並ぶよう）
+    deck: (runState.deck || [])
+      .map((c) => ({
+        libraryKey: c.libraryKey,
+        extId: c.extId,
+        extNameJa: c.extNameJa,
+      }))
+      .sort((a, b) => (a.extNameJa || "").localeCompare(b.extNameJa || "", "ja")),
     llExtSlots: (runState.llExtSlots || []).filter(Boolean).map((e) => ({
       extId: e.extId,
       name: e.name,
@@ -2284,6 +2350,28 @@ function showActivityReport(snap) {
   document.getElementById("reportStage").textContent =
     (snap.isCleared ? "全ステージ制覇 / 最終: " : "到達ステージ: ") + (snap.stageName || "—");
 
+  // レギュレーション表示 (#37)
+  if (snap.regulation) {
+    const regIcon = document.getElementById("reportRegIcon");
+    const regName = document.getElementById("reportRegName");
+    if (regIcon) regIcon.src = snap.regulation.iconUrl;
+    if (regName) {
+      regName.textContent = `Regulation: ${snap.regulation.name}`;
+      if (snap.regulation.color) regName.style.color = snap.regulation.color;
+    }
+  }
+  // 新規アンロック演出
+  const unlockEl = document.getElementById("reportUnlock");
+  if (unlockEl) {
+    if (snap.newlyUnlockedRegulation) {
+      document.getElementById("reportUnlockIcon").src = snap.newlyUnlockedRegulation.iconUrl;
+      document.getElementById("reportUnlockName").textContent = `${snap.newlyUnlockedRegulation.name} 解放！`;
+      unlockEl.classList.remove("hidden");
+    } else {
+      unlockEl.classList.add("hidden");
+    }
+  }
+
   const deckList = document.getElementById("reportDeckList");
   deckList.innerHTML = "";
   snap.deck.forEach((c) => deckList.appendChild(buildExtChip(c)));
@@ -2334,14 +2422,28 @@ function endCombatLoss() {
     if (lastReportSnapshot) {
       await showActivityReport(lastReportSnapshot);
     }
-    // 全ランステートをリセットしてヒーロー選択画面へ戻る
+    // 全ランステートをリセットしてタイトル画面へ戻る (#37: タイトル → レギュレーション選択 → ヒーロー)
     combat = null;
     runState = null;
     clearedChapters = new Set();
     gold = 75;
-    showView("heroSelect");
-    renderHeroSelect();
+    backToTitle();
   });
+}
+
+/** タイトル画面へ戻る（クリア / 敗北 / 「もう一度」共通） (#37) */
+function backToTitle() {
+  // 各 view を hidden にしてタイトル表示
+  ["mapView","combatView","shopView","gameOver","rewardView","nodeSelectView","craftView","heroSelectView","regulationSelectView"].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.classList.add("hidden");
+  });
+  const titleEl = document.getElementById("titleView");
+  if (titleEl) {
+    titleEl.classList.remove("hidden", "title-out");
+  }
+  view = "title";
+  stopBgm();
 }
 
 // ─── ショップ ─────────────────────────────────────────────────────
@@ -2544,8 +2646,8 @@ function resetRun() {
   postCombatSnapshot = null;
   stopBgm();
   dismissCutin();
-  showView("nodeSelect");
-  renderNodeSelect();
+  // タイトル → レギュレーション選択 → ヒーロー選択へ (#37)
+  backToTitle();
 }
 
 // ─── Node 選択画面 ────────────────────────────────────────────────
@@ -2695,6 +2797,68 @@ function togglePassivePopup() {
     `<div class="pp-skill-name">【${skillName}】</div>` +
     `<div class="pp-skill-desc">${skillDesc}</div>`;
   popup.classList.remove("hidden");
+}
+
+// ─── レギュレーション選択画面 (#37) ──────────────────────────────────
+function renderRegulationSelect() {
+  const el = document.getElementById("regulationSelectView");
+  if (!el) return;
+
+  const unlocked = new Set(loadUnlockedRegulations());
+
+  let html = '<div class="rs-header"><h2>レギュレーションを選択</h2><p class="rs-sub">難易度を選んでください。クリアすると次の難易度が解放されます。</p></div>';
+  html += '<div class="rs-list">';
+
+  REGULATIONS.forEach((r) => {
+    const isUnlocked = unlocked.has(r.id);
+    const isCurrent = r.id === currentRegulationId;
+    const cls = ["rs-card"];
+    if (isUnlocked) cls.push("rs-card--unlocked");
+    else cls.push("rs-card--locked");
+    if (isCurrent && isUnlocked) cls.push("rs-card--current");
+
+    html += `<div class="${cls.join(' ')}" data-reg-id="${r.id}" role="button" tabindex="${isUnlocked ? 0 : -1}" aria-disabled="${!isUnlocked}">`;
+    html += `<div class="rs-card-cup">`;
+    html += `<img src="${r.iconUrl}" alt="${r.nameJa}" onerror="this.style.opacity='0.2'" />`;
+    if (!isUnlocked) html += `<span class="rs-lock">🔒</span>`;
+    html += `</div>`;
+    html += `<div class="rs-card-body">`;
+    html += `<div class="rs-card-name" style="color:${r.color}">${r.nameJa}</div>`;
+    html += `<div class="rs-card-desc">${r.descShort}</div>`;
+    if (isUnlocked) {
+      html += `<button class="rs-select-btn action${isCurrent ? ' rs-select-btn--current' : ''}">${isCurrent ? '選択中' : 'このレギュレーションで始める'}</button>`;
+    } else {
+      html += `<div class="rs-locked-hint">前の難易度をクリアで解放</div>`;
+    }
+    html += `</div>`;
+    html += `</div>`;
+  });
+
+  html += '</div>';
+  el.innerHTML = html;
+
+  el.querySelectorAll('.rs-card--unlocked .rs-select-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const card = btn.closest('.rs-card');
+      const id = card?.dataset?.regId;
+      if (!id) return;
+      setCurrentRegulation(id);
+      showView("heroSelect");
+      renderHeroSelect();
+    });
+  });
+}
+
+/** ヘッダーの右上（map / combat 両方）に現在のレギュレーションアイコンを表示 (#37) */
+function updateHeaderRegulationIcons() {
+  const r = getCurrentRegulation();
+  ["headerRegIconMap", "headerRegIconCombat"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.src = r.iconUrl;
+    el.alt = r.nameJa;
+    el.title = `レギュレーション: ${r.nameJa}`;
+  });
 }
 
 // ─── ヒーロー選択画面 ────────────────────────────────────────────────
@@ -2994,9 +3158,12 @@ function init() {
       if (ev.key === "Enter" || ev.key === " ") dismissTitle();
     });
   }
-  // heroSelect を事前にレンダリングしておく（タイトルが覆うので見えない）
-  showView("heroSelect");
+  // ヘッダーアイコン (#37) を初期化
+  updateHeaderRegulationIcons();
+  // 事前に各画面をレンダリング（タイトルが覆うので見えない）
+  renderRegulationSelect();
   renderHeroSelect();
+  showView("heroSelect");
   // BGM はタイトルクリック時に開始（ブラウザのオートプレイ制限のため init では呼ばない）
 
   // ── ヒーローポートレートタップ → パッシブスキル表示 ──────────────

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -3163,7 +3163,8 @@ function init() {
   // 事前に各画面をレンダリング（タイトルが覆うので見えない）
   renderRegulationSelect();
   renderHeroSelect();
-  showView("heroSelect");
+  // 初期 view は regulationSelect: タイトル消失時に一瞬 heroSelect が見える問題を回避
+  showView("regulationSelect");
   // BGM はタイトルクリック時に開始（ブラウザのオートプレイ制限のため init では呼ばない）
 
   // ── ヒーローポートレートタップ → パッシブスキル表示 ──────────────

--- a/prototype/js/regulations.js
+++ b/prototype/js/regulations.js
@@ -1,0 +1,143 @@
+/**
+ * レギュレーション（難易度）定義 (#37)
+ *
+ * 各レベルは前段階の効果を引き継ぐ（cumulative）。
+ * - hpFactor / atkFactor は乗算で累積
+ * - guardPerTurn / bleedOnAttack はフラグ
+ *
+ * イベント / カップ画像は MCH 公式から借用。
+ */
+
+const CUP_BASE = "https://www.mycryptoheroes.net/images/cups/";
+
+export const REGULATIONS = [
+  {
+    id: "common",
+    nameJa: "Common",
+    iconUrl: CUP_BASE + "1304.png",
+    color: "#9aa6b8",
+    descShort: "ベースライン（変更なし）",
+    // cumulative-applied 効果係数とフラグ
+    effects: {
+      hpFactor: 1.0,
+      atkFactor: 1.0,
+      guardPerTurn: 0,
+      bleedOnAttack: 0,
+    },
+  },
+  {
+    id: "egg",
+    nameJa: "Dragon Egg",
+    iconUrl: CUP_BASE + "1303.png",
+    color: "#e3c074",
+    descShort: "敵 HP × 1.1",
+    effects: {
+      hpFactor: 1.1,
+      atkFactor: 1.0,
+      guardPerTurn: 0,
+      bleedOnAttack: 0,
+    },
+  },
+  {
+    id: "baby",
+    nameJa: "Baby Dragon",
+    iconUrl: CUP_BASE + "1302.png",
+    color: "#74cfa3",
+    descShort: "敵 HP × 1.1 / 初期 PHY・INT × 1.2",
+    effects: {
+      hpFactor: 1.1,
+      atkFactor: 1.2,
+      guardPerTurn: 0,
+      bleedOnAttack: 0,
+    },
+  },
+  {
+    id: "blue",
+    nameJa: "Blue Dragon",
+    iconUrl: CUP_BASE + "1301.png",
+    color: "#5aa9ff",
+    descShort: "敵 HP × 1.65 / PHY・INT × 1.2 / 毎ターン初期ガード +3",
+    effects: {
+      hpFactor: 1.1 * 1.5, // 1.65
+      atkFactor: 1.2,
+      guardPerTurn: 3,
+      bleedOnAttack: 0,
+    },
+  },
+  {
+    id: "red",
+    nameJa: "Red Dragon",
+    iconUrl: CUP_BASE + "1300.png",
+    color: "#ff5252",
+    descShort: "敵 HP × 1.65 / PHY・INT × 1.56 / 毎ターン初期ガード +3 / 攻撃に出血付与",
+    effects: {
+      hpFactor: 1.1 * 1.5, // 1.65
+      atkFactor: 1.2 * 1.3, // 1.56
+      guardPerTurn: 3,
+      bleedOnAttack: 1, // 1 スタック
+    },
+  },
+];
+
+/** id → regulation の検索辞書 */
+export const REGULATION_BY_ID = Object.fromEntries(REGULATIONS.map((r) => [r.id, r]));
+
+/** localStorage キー */
+const LS_UNLOCKED = "mct.unlockedRegulations";
+const LS_CURRENT = "mct.currentRegulation";
+
+/** アンロック済みレギュレーション ID 配列をローカルストレージから取得（無ければ ['common']） */
+export function loadUnlockedRegulations() {
+  try {
+    const raw = localStorage.getItem(LS_UNLOCKED);
+    if (raw) {
+      const arr = JSON.parse(raw);
+      if (Array.isArray(arr) && arr.length > 0) return arr;
+    }
+  } catch (e) { /* ignore */ }
+  return ["common"];
+}
+
+/** アンロック状態を保存 */
+export function saveUnlockedRegulations(ids) {
+  try { localStorage.setItem(LS_UNLOCKED, JSON.stringify(ids)); }
+  catch (e) { /* ignore */ }
+}
+
+/** 指定レギュレーションをアンロック（既にアンロック済みなら何もしない） */
+export function unlockRegulation(id) {
+  const cur = loadUnlockedRegulations();
+  if (cur.includes(id)) return cur;
+  const next = [...cur, id];
+  saveUnlockedRegulations(next);
+  return next;
+}
+
+/** 現在選択中のレギュレーション ID を取得（無ければ 'common'） */
+export function loadCurrentRegulationId() {
+  try {
+    const raw = localStorage.getItem(LS_CURRENT);
+    if (raw && REGULATION_BY_ID[raw]) return raw;
+  } catch (e) { /* ignore */ }
+  return "common";
+}
+
+export function saveCurrentRegulationId(id) {
+  if (!REGULATION_BY_ID[id]) return;
+  try { localStorage.setItem(LS_CURRENT, id); }
+  catch (e) { /* ignore */ }
+}
+
+/**
+ * クリア時のアンロック処理。clearedId をクリアした → 次のレギュレーションをアンロック。
+ * @returns {string|null} 新たにアンロックされた ID（なければ null）
+ */
+export function unlockNextAfterClear(clearedId) {
+  const idx = REGULATIONS.findIndex((r) => r.id === clearedId);
+  if (idx < 0 || idx >= REGULATIONS.length - 1) return null;
+  const nextId = REGULATIONS[idx + 1].id;
+  const cur = loadUnlockedRegulations();
+  if (cur.includes(nextId)) return null;
+  unlockRegulation(nextId);
+  return nextId;
+}


### PR DESCRIPTION
## Summary
α版リリース直前の追加機能 2 件:

### #36 微修正 — 活動レポート deck 名前ソート
保有エクステ一覧を `extNameJa` の locale 比較 (ja) で昇順ソート。同シリーズが隣同士に並ぶ。

### #37 機能追加 — 5 段階レギュレーション（アセンション相当）

| Lv | id | 名前 | 効果（cumulative） |
|----|----|------|------|
| 1 | common | Common | 変更なし |
| 2 | egg | Dragon Egg | 敵 HP × 1.1 |
| 3 | baby | Baby Dragon | + 敵 PHY/INT × 1.2 |
| 4 | blue | Blue Dragon | + 敵 HP ×= 1.5（累積 1.65）+ 毎ターン GUARD +3 |
| 5 | red | Red Dragon | + 敵 PHY/INT ×= 1.3（累積 1.56）+ 攻撃に出血付与 |

**画面フロー**:
```
Title → [新設] レギュレーション選択 → ヒーロー選択 → ゲーム
                       ↑                                   ↓
                       └── クリア / 敗北 / もう一度 ───────┘
```
すべてのリトライ系遷移が backToTitle() でタイトルへ戻ります。

**永続化**: localStorage `mct.unlockedRegulations` / `mct.currentRegulation`

**ヘッダーアイコン**:
- マップ系: `.resources` バー（デッキ表示の右、? の左）
- 戦闘ヘッダー: `.combat-header-btns`（デッキ表示の右、⚙ の左）

**活動レポート**: Regulation: 名前 + アイコン、全章クリア時は「★ NEW UNLOCK ★」演出

**アセット**: MCH 公式 cup 画像 (`https://www.mycryptoheroes.net/images/cups/13xx.png`) を借用。

## 実装ファイル
- 新規: `prototype/js/regulations.js`（データ + localStorage helper）
- 改修: `prototype/js/main.js`、`prototype/index.html`

## 動作確認
- シミュレータ (sim/run.js) は regulations を参照しないため挙動不変。1500 ラン確認済み:
  ch1 89% / ch2 63% / ch3 12% / ch4 20% (n=12) / ch5 0%

## Test plan
- [ ] 初回起動: タイトル → レギュレーション選択 → Common のみ選択可
- [ ] Common クリア → 活動レポート → ★ NEW UNLOCK ★ + Dragon Egg 解放
- [ ] リロード後も Dragon Egg がアンロック維持されている
- [ ] Dragon Egg 選択 → 敵 HP が 1.1 倍になっている
- [ ] Blue Dragon: 敵ターン開始で GUARD +3 表示
- [ ] Red Dragon: 敵攻撃後にプレイヤーに出血スタック付与
- [ ] ヘッダー右上にカップアイコンが表示される（マップ・戦闘両方）
- [ ] 敗北 → 活動レポート → 閉じる → タイトル → レギュレーション選択 → ヒーロー選択
- [ ] 活動レポートのエクステ一覧が名前順で並ぶ

## 関連
- #36, #37 でリンク

🤖 Generated with [Claude Code](https://claude.com/claude-code)