### PR TITLE
chore(release): タブ表示/favicon/OGP + 白画面対策 + X 投稿時のスクショ添付

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -3,8 +3,32 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>クロノ・デッキ（プロトタイプ）</title>
+  <title>MyCryptoTactics — アルファ版</title>
+  <meta name="description" content="My Crypto Heroes の偉人たち × ローグライク × カードバトルのファンメイドブラウザゲーム。" />
+
+  <!-- favicon -->
+  <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/bearko/mycryptoheroes/main/MAI_SD.png" />
+
+  <!-- Open Graph / Twitter Card (X リンクプレビュー用) -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="MyCryptoTactics — アルファ版" />
+  <meta property="og:description" content="My Crypto Heroes の偉人たち × ローグライク × カードバトル。スマホ・PC で遊べるブラウザゲーム。" />
+  <meta property="og:url" content="https://mycryptotactics.vercel.app/" />
+  <meta property="og:image" content="https://raw.githubusercontent.com/bearko/mycryptoheroes/main/MAI_SD.png" />
+  <meta property="og:site_name" content="MyCryptoTactics" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="MyCryptoTactics — アルファ版" />
+  <meta name="twitter:description" content="My Crypto Heroes 偉人 × ローグライク × カードバトル。" />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/bearko/mycryptoheroes/main/MAI_SD.png" />
+
+  <!-- 一瞬の白画面を回避するため、CSS 読み込み前に body 背景色を即時設定 -->
+  <style>html, body { background: #121018; color: #e6e0f0; margin: 0; }</style>
+
   <link rel="preconnect" href="https://raw.githubusercontent.com" />
+
+  <!-- 活動レポートのスクリーンショット生成用 (#X 投稿時に使用) -->
+  <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+
   <style>
     :root {
       --bg: #121018;

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -2399,18 +2399,78 @@ function showActivityReport(snap) {
       overlay.setAttribute("aria-hidden", "true");
       resolve();
     });
-    newShare.addEventListener("click", () => {
+    newShare.addEventListener("click", async () => {
       const intro = snap.isCleared
         ? `${snap.hero.name} で全ステージ制覇しました！`
         : `${snap.hero.name} で「${snap.stageName}」まで到達。${snap.opponent.name} に倒された…`;
-      // Twitter Web Intent: text / url / hashtags を分けて渡すと自然に組み立てられる。
-      // hashtags はカンマ区切りで # なし。`#MyCryptoTactics` が末尾に付く。
-      const url =
+      const intentUrl =
         `https://twitter.com/intent/tweet` +
         `?text=${encodeURIComponent(intro)}` +
         `&url=${encodeURIComponent(SHARE_URL)}` +
         `&hashtags=${encodeURIComponent(SHARE_TITLE)}`;
-      window.open(url, "_blank", "noopener,noreferrer");
+
+      // 旧フォールバック (html2canvas が無い / 失敗時)
+      const openIntentOnly = () => window.open(intentUrl, "_blank", "noopener,noreferrer");
+
+      // html2canvas で活動レポートをスクショ → 共有 or ダウンロード
+      const targetEl = overlay.querySelector(".report-card");
+      if (!targetEl || typeof window.html2canvas !== "function") {
+        openIntentOnly();
+        return;
+      }
+
+      newShare.disabled = true;
+      const originalLabel = newShare.textContent;
+      newShare.textContent = "画像生成中…";
+
+      try {
+        const canvas = await window.html2canvas(targetEl, {
+          backgroundColor: "#0f0c18",
+          useCORS: true,
+          allowTaint: true,
+          scale: window.devicePixelRatio > 1 ? 2 : 1.5,
+          logging: false,
+        });
+        const blob = await new Promise(res => canvas.toBlob(res, "image/png"));
+        const filename = `mct-report-${Date.now()}.png`;
+        const file = blob ? new File([blob], filename, { type: "image/png" }) : null;
+
+        // モバイル等で Web Share API + ファイル共有が使える場合: 画像を直接添付して共有
+        if (file && navigator.canShare && navigator.canShare({ files: [file] }) && navigator.share) {
+          try {
+            await navigator.share({
+              files: [file],
+              text: `${intro} #${SHARE_TITLE}`,
+              url: SHARE_URL,
+            });
+            return; // 完了
+          } catch (e) {
+            // 共有キャンセルや拒否 → フォールバックへ
+            if (e && e.name === "AbortError") return;
+          }
+        }
+
+        // フォールバック: 画像をダウンロード + Twitter Intent を開く + 案内
+        if (blob) {
+          const dlUrl = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = dlUrl; a.download = filename;
+          document.body.appendChild(a); a.click();
+          document.body.removeChild(a);
+          setTimeout(() => URL.revokeObjectURL(dlUrl), 4000);
+        }
+        openIntentOnly();
+        // ユーザーへの案内（一度だけ）
+        try {
+          window.alert("活動レポート画像をダウンロードしました。X 投稿画面で「画像を添付」から手動で添付してください。");
+        } catch (_) {}
+      } catch (err) {
+        // html2canvas が CORS や renderer 制限で失敗した場合 → テキストのみ共有
+        openIntentOnly();
+      } finally {
+        newShare.disabled = false;
+        newShare.textContent = originalLabel;
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
リリース前体裁・共有機能の改善 4 件:

### 1. タブ表示名 → MyCryptoTactics
\`<title>クロノ・デッキ（プロトタイプ）</title>\` → \`<title>MyCryptoTactics — アルファ版</title>\`

### 2. favicon
\`<link rel="icon">\` で MAI_SD.png を指定。

### 3. 初期表示の白画面チラつき回避
CSS 読み込み前のレンダリングで一瞬白くなる問題に対し、\`<head>\` 内 \`<style>\` で \`html, body { background: #121018 }\` を即時設定。

### 4. OGP / Twitter Card（X リンクプレビューのサムネ）
- \`twitter:card = summary_large_image\`
- \`og:image / twitter:image = MAI_SD.png\`
- \`og:title / twitter:title = MyCryptoTactics — アルファ版\`
- \`og:description / twitter:description = MCH 偉人 × ローグライク × カードバトル\`

→ X で \`https://mycryptotactics.vercel.app/\` を貼ったときに大きな画像 + タイトル + 説明が表示される。

### 5. 活動レポートを画像付きで X 共有
- \`html2canvas\` を CDN から defer 読み込み（~80KB）
- 「𝕏 で共有」ボタン押下時に \`.report-card\` をキャプチャ
- **モバイル等で Web Share API + ファイル共有が使える環境**: \`navigator.share({files})\` で画像ファイル添付付き共有 → X アプリに画像つきで送れる
- **フォールバック (PC ブラウザ等)**: PNG を自動ダウンロード + Twitter Web Intent を開く + 「ダウンロードした画像を手動で添付してください」ガイダンス
- html2canvas が読めない / CORS で失敗した場合は従来通りテキストのみ共有

## Test plan
- [ ] タブ表示名が「MyCryptoTactics — アルファ版」になっている
- [ ] タブのアイコンが MAI_SD（マイ）になっている
- [ ] アプリ起動時に白画面のチラつきが消えている
- [ ] X で URL を貼ったプレビューに画像 + タイトル + 説明が出る（OGP デバッガで確認: https://cards-dev.twitter.com/validator）
- [ ] PC ブラウザで活動レポート → 𝕏 で共有 → 画像が DL + 投稿画面が開く + 案内が出る
- [ ] スマホ Safari/Chrome で活動レポート → 𝕏 で共有 → ネイティブ共有シートが出て X アプリに画像つきで送れる

## 補足: 403 / 一瞬の白画面（コード対応外）
- **Vercel preview の 403**: Vercel ダッシュボード → mycryptotactics → Settings → Deployment Protection が ON になっている可能性。本番ドメインも 403 なら ON / Vercel Authentication 確認、Public で公開するなら **Off** に。
- **本番アクセス時の一瞬の白画面**: 本 PR の即時 background 設定で目立たなくなるはず。残る場合は CDN の html2canvas や MCH アセットの読み込みタイミング次第。

🤖 Generated with [Claude Code](https://claude.com/claude-code)