### PR TITLE
fix(regulation): レギュレーション変更時に章クリア進捗をリセット (#42)

### DIFF
--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -49,9 +49,20 @@ function getCurrentRegulation() {
 }
 function setCurrentRegulation(id) {
   if (!REGULATION_BY_ID[id]) return;
+  const changed = currentRegulationId !== id;
   currentRegulationId = id;
   saveCurrentRegulationId(id);
   updateHeaderRegulationIcons();
+  // レギュレーション変更時は章クリア進捗もリセット (#42)
+  // → 別レギュレーションでは必ずアバカスからやり直し
+  if (changed) {
+    clearedChapters = new Set();
+    runState = null;
+    gold = 75;
+    pendingShopNodeId = null;
+    pendingCraftNodeId = null;
+    postCombatSnapshot = null;
+  }
 }
 
 // ─── ナビゲーター「マイ」 ────────────────────────────────────────
@@ -2706,6 +2717,8 @@ function resetRun() {
   gold = 75;
   combat = null;
   runState = null;
+  // 全クリア後の「もう一度」でも章クリア進捗を確実にリセット (#42)
+  clearedChapters = new Set();
   pendingShopNodeId = null;
   pendingCraftNodeId = null;
   postCombatSnapshot = null;


### PR DESCRIPTION
## Summary
レギュレーション変更後 / 全クリア後の「もう一度」で nodeSelect の全章解放状態が引き継がれてしまうバグを修正。

## 再現
1. Common 全クリア → Dragon Egg 解放
2. タイトル → レギュレーション選択 → Dragon Egg を選択
3. ヒーロー選択 → nodeSelect 画面
4. **全 5 章すべて unlocked 状態**で表示される（本来はアバカスのみ）

## 原因
\`clearedChapters\`（章クリア記録 \`Set<number>\`）が以下 2 箇所でリセットされていなかった:
- \`resetRun()\`（「もう一度」ボタン）
- \`setCurrentRegulation(id)\`（レギュレーション切り替え）

前ランの \`{0,1,2,3,4}\` が残った状態で nodeSelect が \`isUnlocked = clearedChapters.has(idx-1)\` を評価 → 全章解放判定。

## 修正
- \`resetRun()\` に \`clearedChapters = new Set()\` を追加
- \`setCurrentRegulation(id)\` で id が変わった時に \`clearedChapters\` / \`runState\` / \`gold\` / \`pending\*\` / \`postCombatSnapshot\` を初期化（別レギュレーションでは必ずアバカスからやり直し）

## Test plan
- [ ] Common 全クリア → 「もう一度」→ レギュレーション選択 → Dragon Egg → ヒーロー → nodeSelect でアバカスのみ unlocked
- [ ] Common 全クリア → 「もう一度」→ レギュレーション選択 → Common（同じ）→ アバカスのみ unlocked
- [ ] Common 中で 死亡 → リトライ → アバカスのみ unlocked（既存動作維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)