### PR TITLE
feat(alpha+): SPEC-005 起草 + Phase 1 ターゲット指定バッジ表示（既存挙動維持）

### DIFF
--- a/docs/specs/SPEC-005-party-3v3.md
+++ b/docs/specs/SPEC-005-party-3v3.md
@@ -1,0 +1,427 @@
+# SPEC-005: パーティ編成（3v3）+ ターゲット指定システム
+
+| 項目 | 値 |
+|------|-----|
+| ID | SPEC-005 |
+| 状態 | Draft |
+| 作成日 | 2026-05-01 |
+| 最終更新 | 2026-05-01 |
+| 作者 | bearko + Claude Code |
+| 想定リリース | β版（3 日後目標） |
+
+## 1. 概要
+
+α版までは 1 ヒーロー対 1 エネミーの 1v1 戦闘だったが、β版では **最大 3 ヒーロー対最大 3 エネミー** のパーティ戦に拡張する。
+
+これに伴い、各エクステンション（カード）に **「誰が誰に効果を与えるか」のターゲット指定** を導入する。元の MyCryptoHeroes の各エクステの効果説明に準拠する語彙を用いる。
+
+## 2. 背景と動機
+
+- α版で実装した「node 間でのデッキ持ち越し」「レギュレーション」によりやり込み深度は増したが、戦術の幅は依然として 1v1 → カード選択のみに留まっている
+- MCH 原作のような **パーティ構築 × シナジー × ターゲット選択** が β の目玉
+- ヒーローパッシブが 3 体構成で **シナジー**（例: 1 体目のパッシブで全体デバフ → 2 体目が「デバフ中の敵にダメージ +X」）を生む設計余地が広がる
+- 敵側にも **パッシブ** を付けて難易度の天井を上げる
+
+## 3. 目標と非目標
+
+### 目標（Goals）
+
+- 自軍 1〜3 ヒーローのパーティ編成画面を新設し、戦闘で同時運用
+- 章ごとに 1〜3 体のエネミーを配置可能とし、敵側もパーティ単位で意図表示・行動
+- カードの効果に **ターゲット指定**（前衛/中衛/後衛/先頭/最後尾/全体/ランダム/最 PHY 高低 等）を導入
+- カード上の旧「先頭」テキスト表示を、**そのカードの実ターゲット指定** を表す視覚要素に置換
+- 既存エクステの効果定義を MCH 公式データに準拠する形で再整理（最低限既存全カードに target を付与）
+- ヒーローパッシブをシナジー前提に再設計可能にする
+- 敵にもパッシブを 1〜2 種付与（β v1 では 2〜3 ボスのみで OK）
+
+### 非目標（Non-goals）
+
+- ヒーロー編成のドラッグ&ドロップ並び替え（v1 はリスト + ボタンで OK）
+- ヒーロー召喚・蘇生・退場時のドラマ演出（v2 以降）
+- マルチプレイヤー / オンライン対戦（β は単独プレイ継続）
+- シミュレータ（`prototype/sim/`）の 3v3 完全対応（β1 は単純化、または 1v1 のままでメトリクスを取らない）
+
+## 4. スコープ
+
+### 含む
+
+- 戦闘エンジンの `combat.heroes` / `combat.enemies` を配列化
+- ターゲット解決アルゴリズム
+- カード `play()` への解決済みターゲット渡し
+- パーティ編成画面（ヒーロー選択画面の発展形）
+- 戦闘 UI 3v3 レイアウト
+- 敵 AI の対象選択
+- 既存エクステへの target 一括付与（自動移行 + 手動補正）
+- ヒーロー / エネミーのパッシブシステム拡張
+
+### 含まない
+
+- 過去レギュレーションの再バランス（β1 は β 用に専用バランスから始める）
+- 全エクステの効果再設計（既存効果を維持しつつ target だけ付与する移行を許容）
+- セーブ / ロード機能（依然リロードでリセット）
+
+## 5. 用語
+
+| 用語 | 意味 |
+|------|------|
+| **ユニット (unit)** | 戦闘中の 1 体（ヒーローまたはエネミー） |
+| **パーティ (party)** | 同陣営のユニット配列（最大 3）。`heroes[3]` / `enemies[3]` |
+| **ポジション** | ユニット配置位置（前衛 / 中衛 / 後衛）。**画面中央に近い側を「前衛」**とする |
+| **キャスター (caster)** | カードを使うヒーロー（プレイヤーが選択） |
+| **ターゲット (target)** | カード効果が適用される対象ユニット |
+| **ターゲット仕様 (TargetSpec)** | カード定義に書く「どんな対象を選ぶか」の宣言 |
+
+## 6. ターゲット仕様の語彙
+
+カード定義に書く `target` フィールドの値（文字列定数）。
+
+| 仕様 | 識別子 | 意味 |
+|------|--------|------|
+| 自分 | `self` | カードを使うキャスター自身 |
+| 味方 前衛 / 中衛 / 後衛 | `ally.front` / `ally.mid` / `ally.back` | 指定ポジションの味方（死亡時は `null` → 効果なし） |
+| 敵 前衛 / 中衛 / 後衛 | `enemy.front` / `enemy.mid` / `enemy.back` | 同上 |
+| 先頭 (敵 / 味方) | `enemy.foremost` / `ally.foremost` | 生存中で最も画面中央に近い 1 体 |
+| 最後尾 (敵 / 味方) | `enemy.rearmost` / `ally.rearmost` | 生存中で最も外側の 1 体 |
+| 全体 (敵 / 味方 / 全) | `enemy.all` / `ally.all` / `all` | 生存中の全ユニット |
+| ランダム (敵 / 味方 / 全) | `enemy.random` / `ally.random` / `all.random` | 生存中からランダム 1 体 |
+| 最も高い / 低い (PHY/INT/HP) | `enemy.highest_phy` ほか | 最大値 / 最小値を持つ 1 体 |
+
+**「先頭」の解決ルール**: 前衛 → 中衛 → 後衛 の順で最初の生存ユニットを返す。「最後尾」は後衛 → 中衛 → 前衛。
+
+## 7. データモデル
+
+### 7.1 Unit 型（ヒーロー / エネミー共通）
+
+```ts
+type Unit = {
+  side: 'hero' | 'enemy';
+  position: 0 | 1 | 2;          // 0=前衛, 1=中衛, 2=後衛
+  alive: boolean;
+  // ステータス
+  hp: number; hpMax: number;
+  phy: number; int: number; agi: number;
+  phyBase: number; intBase: number; agiBase: number;
+  guard: number; shield: number;
+  poison: number; bleed: number; vulnerable: number;
+  // 識別
+  defId: string;                // hero: heroId / enemy: enemyDefId
+  name: string;
+  imgId?: number;               // for ENEMY_IMG / HERO portrait
+  // ヒーロー固有
+  passiveKey?: string;
+  passiveTriggered?: boolean;
+  // エネミー固有
+  intentRota?: Intent[];
+  intentRotaIdx?: number;
+  enemyIntent?: Intent;
+  bossPhase?: number; bossDef?: any;
+};
+```
+
+### 7.2 RunState の変更
+
+```ts
+runState = {
+  chapterIdx, lastMapNodeId, pathNodeIds, runComplete,
+  llExtSlots,
+  // ▼ 変更
+  party: HeroLoadout[],         // 配列。長さ 1〜3。各要素が選択ヒーロー＋HP状態
+  // ヒーロー死亡時に runState のどれが死んでいるか保持
+  // deck は party 全員で共有（v1 は共有方針、v2 で個別検討）
+  deck: Card[],
+  shopRemoveUsed?, unlockedRegulationOnClear?,
+};
+
+type HeroLoadout = {
+  heroId: number;
+  hpCurrent: number; hpMax: number;  // ノード間で持ち越し
+};
+```
+
+### 7.3 Combat State
+
+```ts
+combat = {
+  // ▼ 配列化（旧 playerXxx / enemyXxx を heroes[] / enemies[] へ）
+  heroes: Unit[],     // length 1〜3
+  enemies: Unit[],    // length 1〜3
+  activeHeroIdx: number,    // カード使用時のキャスター（プレイヤーが切替）
+  // 既存維持
+  deck, drawPile, discardPile, exhaustPile, hand,
+  energy, energyMax, bonusEnergyNext, phyPenaltyNext,
+  damageReducedThisTurn,
+  turn,
+  isBoss, mapNodeId, isElite,
+  // パッシブ管理は heroes[] / enemies[] の各 unit に持たせる
+};
+```
+
+### 7.4 カード定義の拡張
+
+```ts
+ext1001: {
+  libraryKey: 'ext1001',
+  extId: 1001,
+  extNameJa: 'ノービスブレード',
+  skillNameJa: 'ノービススラッシュ',
+  skillIcon: 'phy.png',
+  cost: 1,
+  type: 'atk',
+  rarity: 'common',
+  // ▼ 新規
+  target: 'enemy.foremost',           // ターゲット仕様
+  selfTarget?: 'self',                 // 自身に副次効果がある場合
+  // 効果記述（カード上のサマリーに使う）
+  // 既存 effectSummaryLines / previewLines は引き続き使用、
+  // ただし「先頭」テキストはターゲット表示に置換
+  effectSummaryLines(s, caster) { ... },
+  previewLines(s, caster) { ... },
+  // ▼ play は解決済みターゲット配列を受け取る
+  play(s, ctx) {
+    // ctx = { caster: Unit, primaryTargets: Unit[], selfTarget?: Unit, sides... }
+    for (const t of ctx.primaryTargets) {
+      api.dealPhySkillTo(s, ctx.caster, t, 65, 80);
+    }
+  },
+}
+```
+
+複合効果（敵にダメ + 自分に PHY+）の場合は `target` (主) と `selfTarget` (副) を分ける。または `effects: [{...}]` 配列で完全宣言型に。後者のほうが将来的に柔軟だが β1 では前者で十分。
+
+## 8. ターゲット解決アルゴリズム
+
+```ts
+function resolveTargets(spec, caster, combat) {
+  const myParty = caster.side === 'hero' ? combat.heroes : combat.enemies;
+  const enemyParty = caster.side === 'hero' ? combat.enemies : combat.heroes;
+
+  switch (spec) {
+    case 'self': return [caster];
+    case 'ally.front': return [aliveAt(myParty, 0)].filter(Boolean);
+    case 'ally.mid':   return [aliveAt(myParty, 1)].filter(Boolean);
+    case 'ally.back':  return [aliveAt(myParty, 2)].filter(Boolean);
+    case 'enemy.front': return [aliveAt(enemyParty, 0)].filter(Boolean);
+    // ...
+    case 'enemy.foremost': return [foremostAlive(enemyParty)].filter(Boolean);
+    case 'enemy.rearmost': return [rearmostAlive(enemyParty)].filter(Boolean);
+    case 'enemy.all': return enemyParty.filter(u => u.alive);
+    case 'ally.all': return myParty.filter(u => u.alive);
+    case 'all': return [...myParty, ...enemyParty].filter(u => u.alive);
+    case 'enemy.random': return pickRandom(enemyParty.filter(u => u.alive));
+    case 'enemy.highest_phy': return pickByMax(enemyParty.filter(u => u.alive), u => u.phy);
+    case 'enemy.lowest_hp': return pickByMin(enemyParty.filter(u => u.alive), u => u.hp);
+    // ...
+  }
+}
+
+function aliveAt(party, pos) {
+  return party.find(u => u.position === pos && u.alive);
+}
+function foremostAlive(party) {
+  for (let p = 0; p < 3; p++) {
+    const u = aliveAt(party, p);
+    if (u) return u;
+  }
+  return null;
+}
+function rearmostAlive(party) {
+  for (let p = 2; p >= 0; p--) {
+    const u = aliveAt(party, p);
+    if (u) return u;
+  }
+  return null;
+}
+```
+
+ヒット 0 体（全員死亡 等）の場合は **効果スキップ**、エネルギーは消費する設計とする（プレイヤーへのフィードバックは「対象がいません」表示）。
+
+## 9. 戦闘エンジンの変更
+
+### 9.1 損傷適用ヘルパ
+
+旧: `dealPhySkillFromEnemyToPlayer(combat, phyPct)`
+新: `dealPhySkillFrom(caster, target, phyPct)` のように **caster, target 両方を引数に取る** 形へ統一。
+
+### 9.2 ターン制御
+
+- プレイヤーターン: 全ヒーロー共有のエネルギー (3) を使ってカードを切る。各カードのキャスターはプレイヤーが選択（v1 は **デフォルト = activeHeroIdx**、UI で切替可能）。
+- 敵ターン: 各エネミーが順番に intent を実行。intent ごとに対象解決 → 効果適用。
+- 状態異常（毒・出血）は各ユニットのターン開始時に処理。
+
+### 9.3 プレイヤーキャスター切替 UI
+
+カードを使う前に「どのヒーローが使うか」を選択する必要がある。
+- v1 は **クリック方式**: ヒーローポートレートをタップ → activeHeroIdx 設定 → カードタップで使用
+- v2 は ドラッグ&ドロップ
+- 自動キャスター推定（カードの最適キャスターを推測）は v2 以降
+
+## 10. UI / 表示
+
+### 10.1 戦闘画面レイアウト
+
+```
+┌──────────────────────────────────────┐
+│  [GUM] [LL] [Stage] [Reg] [⚙][?][📚] │
+├────────────┬─────────────────────────┤
+│ ヒーロー縦3 │  vs   │  エネミー縦3   │
+│  [前]      │       │   [前]         │
+│  [中]      │       │   [中]         │
+│  [後]      │       │   [後]         │
+├────────────┴─────────────────────────┤
+│ ログ                                  │
+│ ⚡3/3                          [End]  │
+│ [card][card][card][card][card]       │
+└──────────────────────────────────────┘
+```
+
+- ヒーロー / エネミー縦 3 段配置（モバイル縦持ち優先）
+- アクティブキャスターはハイライト枠
+- 死亡ユニットは半透明 + ✕ オーバーレイ
+- ステータスバッジ（毒・出血・ガード）はユニット直上
+- 敵 intent はユニット上にバルーン表示（既存のスタイル踏襲）
+
+### 10.2 カード上のターゲット表示
+
+旧: テキスト「先頭」バッジ
+新: ターゲット仕様に応じた **小型アイコン / ヒーロー portrait**
+
+| TargetSpec | 表示 |
+|------------|------|
+| `enemy.front/mid/back` | 該当エネミーの portrait（小） |
+| `ally.front/mid/back` | 該当ヒーローの portrait（小） |
+| `enemy.foremost` | 動的に変わる: 現在の先頭エネミーの portrait |
+| `enemy.all` | 「全」バッジ + 敵側カラー |
+| `ally.all` | 「全」バッジ + 味方側カラー |
+| `all` | 「全」バッジ |
+| `*.random` | 「?」バッジ + 該当陣営カラー |
+| `enemy.highest_phy` 等 | 「PHY↑」「HP↓」等のミニアイコン |
+| `self` | キャスター自身の portrait |
+
+ユーザー添付画像 2 のように、**カード右下に円形ポートレート** で配置。ターゲット未確定（ランダム/動的）は陣営カラーの `?` チップ。
+
+### 10.3 敵 Intent 表示
+
+各エネミーの上に「→ 敵: 前衛 PHY 12」のバルーン。MCH 原作風の小型アイコン + 値で。
+
+## 11. 敵 AI（v1）
+
+シンプルに開始:
+
+- 攻撃系 intent (`attack` 等) → デフォルト `target: 'enemy.foremost'` に解決（敵から見ると hero.foremost）
+- 全体攻撃系 → `enemy.all`
+- ランダム選択 intent はカード定義側で `target: 'enemy.random'` を持つ
+- バフ / 自己回復 → `self`
+- 将来: 「最も HP の低いヒーロー狙い」「PHY が高い敵を優先」等のロジックを intentDef に持たせる
+
+## 12. ヒーロー / エネミーパッシブの拡張
+
+### 12.1 ヒーローパッシブ
+既存の 3 種（甲斐姫・ドイル・張遼）は **個人発動型**。β1 では既存動作を維持しつつ、効果対象を 3v3 に拡張:
+
+- 甲斐姫「浪切」: スキル使用後 50% で **先頭の敵に PHY 50% ダメ** ← `enemy.foremost` 解釈
+- 張遼「遼来遼来」: 被ダメ後 50% で **先頭の敵に PHY 20% ダメ** ← 同上
+- ドイル「シャーロック・ホームズ」: HP<70% で INT+3 ← self
+
+新パッシブ案（β1 で 1〜2 種追加）:
+- **「庇う」**: 味方が攻撃される → 自分が代わりに被弾 + ガード+5 自己付与
+- **「奮起」**: 味方が倒れた瞬間に PHY+5（永続）
+
+### 12.2 エネミーパッシブ
+β v1 では **2〜3 種** を限定ボス / elite に付与:
+
+- **「再生」**: ターン終了時 HP+5
+- **「咆哮」**: 戦闘開始時に味方全体 PHY+3
+- **「断末魔」**: 死亡時に hero 全体に出血 +1
+
+`enemyDef.passiveKey` と `enemyDef.passiveDesc` を追加し、戦闘時にトリガー判定。
+
+## 13. マイグレーション計画
+
+### Phase 0: 設計 + 足場（β-day 0）
+- 本 SPEC レビュー
+- branch `feat/beta-party-3v3` 作成（済）
+- 既存コードへの影響範囲洗い出し
+
+### Phase 1: ターゲット仕様の付与（β-day 1）
+- 全 ext1xxx / ext2xxx / cdXxx に `target` を一括付与（既存挙動 = `enemy.foremost`）
+- `target` フィールドは付くが、戦闘ロジックはまだ 1v1（旧 `playerHp / enemyHp` 構造のまま）
+- カード上の「先頭」テキストを `target` 指定に応じた表示に置換（**この段階で UI 改善のみリリース可能**）
+
+### Phase 2: データモデル配列化（β-day 1〜2）
+- `combat.heroes / combat.enemies` を配列化
+- 旧 `playerHp` 等を `combat.heroes[0].hp` への shim でつないで段階移行
+- 既存 1v1 戦闘が新構造で動くことを確認
+
+### Phase 3: 3v3 戦闘 + UI（β-day 2）
+- パーティ編成画面
+- 3v3 戦闘画面レイアウト
+- アクティブキャスター切替
+- 敵 AI 簡易実装（先頭ヒーロー優先 / 全体攻撃のみ全員）
+- ターゲット解決アルゴリズム適用
+
+### Phase 4: 敵パッシブ + 既存ヒーローパッシブ拡張（β-day 3）
+- 既存 3 ヒーローのパッシブを 3v3 解釈に対応
+- 2〜3 ボス / elite に passive 付与
+- balance pass（β 用に新規）
+
+### Phase 5: シミュレータ更新（post-β）
+- v1 リリース時点では sim は 1v1 のまま、計測精度を諦める
+- β 安定化後に 3v3 sim を別 Issue で対応
+
+## 14. 影響範囲（既存コード）
+
+| ファイル | 変更レベル | 内容 |
+|----------|-----------|------|
+| `prototype/js/main.js` | **大** | combat / runState の配列化、UI レンダリング、キャスター切替 |
+| `prototype/js/cards.js` | **大** | 全カードに target 付与、play(s) → play(s, ctx) シグネチャ変更 |
+| `prototype/js/battle-mch.js` | 小 | ダメージ計算自体は維持。ヘルパで caster/target を引数に |
+| `prototype/js/enemies.js` / `bosses.js` | 中 | 各 enemyDef に passive を追加可能に |
+| `prototype/js/constants.js` / `heroes.js` | 中 | hero passive メタ拡張 |
+| `prototype/js/regulations.js` | 小 | β 専用係数を追加検討 |
+| `prototype/index.html` | **大** | 戦闘画面 3 段レイアウト、パーティ編成画面、カードターゲット表示 CSS |
+| `prototype/sim/*` | 後回し | β v1 では更新せず、別 Issue |
+| `prototype/data/*.json` + `tools/sync_csv_json.js` | 中 | enemyDef.passive、ext.target を CSV 同期に追加 |
+
+## 15. リスクと軽減策
+
+| # | リスク | 影響 | 軽減策 |
+|---|--------|------|--------|
+| R1 | 3 日で 3v3 完全実装はタイトすぎる | スケジュール超過 | Phase 1 (target 表示) と Phase 2 (配列化) で **段階的にリリース可能** にする。3v3 が間に合わなくても α 改良としてリリース可 |
+| R2 | バランスが完全に崩れる | プレイ感悪化 | β 専用レギュレーション「β-Common」を設けて Common とは独立に balance |
+| R3 | カード一括移行で既存挙動が壊れる | リグレッション | Phase 1 で **target を加えるだけ・play() は不変** に保つ。挙動変化は意図的な箇所のみ |
+| R4 | AI の対象選択がプレイヤーに不利 | 体験悪化 | v1 は単純に「ヒーロー先頭優先」、ランダム要素を抑制 |
+| R5 | sim が 1v1 のまま β を出すとデータ駆動 balance ができない | 開発効率 | β v1 は手動 balance、sim 対応は v1.1 |
+| R6 | UI が混雑（3v3 + ステータスバッジ + intent + ターゲット表示）| 視認性悪化 | レイアウトをモバイル縦持ち優先で設計、PC は横持ち最適化を後回し |
+| R7 | 既存セーブ（無いが localStorage 上のレギュレーション解放状態）が破綻 | ユーザー混乱 | 解放状態キーは **β 専用キー** を新設（`mct.unlockedRegulations.beta`） |
+
+## 16. 受け入れ基準
+
+### β v1（最小ライン、3 日後）
+- [ ] 全エクステに `target` フィールドが付与されている
+- [ ] カード表示の旧「先頭」テキストが target に応じた表示に変わる（α でも有効）
+- [ ] パーティ編成画面で 1〜3 ヒーローを選択できる
+- [ ] 戦闘で 3 ヒーロー × 3 エネミー（章による）が表示・行動する
+- [ ] アクティブキャスター切替 + ターゲット解決が動く
+- [ ] 既存の単体エネミー戦が新構造で破綻なく動く
+- [ ] β 用レギュレーションで一通りクリア可能
+
+### β v1.x（リリース後 1〜2 週）
+- [ ] エネミーパッシブ 2 種以上が稼働
+- [ ] 新ヒーローパッシブ 1 種追加（シナジー誘発型）
+- [ ] sim 3v3 対応 → balance ループ再開
+
+## 17. 未決事項（要ディスカッション）
+
+- [ ] **デッキ共有 vs ヒーロー個別**: β1 は全員共有想定。MCH 原作的にはヒーロー固有エクステがある。どこまで再現するか？
+- [ ] **エネルギー (⚡) の所有**: 共有 (3) でよいか、ヒーローごとに 1 ずつ持つか
+- [ ] **ヒーロー死亡 → 復活**: 復活手段は β v1 で実装するか
+- [ ] **編成変更**: ラン中にパーティを入れ替えられるか（ショップ等で）
+- [ ] **ボス戦の party 構成**: β でもボスは 1 体のままか、フェーズ違いの 3 体か
+
+これらは設計レビュー時に確定。
+
+## 18. 関連
+
+- 既存 SPEC: SPEC-002（戦闘 UX）, SPEC-003（公開要件）, SPEC-004（章コンテンツ）
+- 参照: [bearko/mycryptoheroes Data/Extensions](https://github.com/bearko/mycryptoheroes/tree/main/Data/Extensions)
+- branch: `feat/beta-party-3v3`

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -17,6 +17,7 @@
 | SPEC-002.5 | プロトタイプ現況スナップショット | Draft | [SPEC-002.5-prototype-snapshot.md](./SPEC-002.5-prototype-snapshot.md) |
 | SPEC-003 | 一般公開リリース要件 | Draft | [SPEC-003-public-release.md](./SPEC-003-public-release.md) |
 | SPEC-004 | ステージコンテンツ（章 1〜章 3） | Draft | [SPEC-004-stage-content.md](./SPEC-004-stage-content.md) |
+| SPEC-005 | パーティ編成（3v3）+ ターゲット指定システム | Draft | [SPEC-005-party-3v3.md](./SPEC-005-party-3v3.md) |
 
 ## 廃止（Deprecated）
 

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -923,28 +923,29 @@
       text-shadow: 0 1px 2px #000; z-index: 3;
     }
     .reward-card-inner .card-ext-name {
-      position: absolute; left: 0.22rem; right: 0.22rem; bottom: 35%; z-index: 7;
-      /* container query: クエリ可能なら親幅基準 (cqw)、不可なら従来 (vw) */
-      font-size: clamp(0.46rem, 8.5cqw, 0.7rem); font-weight: 700;
+      position: absolute; left: 0.22rem; right: 0.22rem; bottom: 38%; z-index: 7;
+      /* container query: 親幅基準 (cqw) で自動スケール、上限/下限を引き上げ */
+      font-size: clamp(0.6rem, 11cqw, 0.95rem); font-weight: 700;
       color: var(--text); text-shadow: 0 1px 3px #000c;
-      line-height: 1.15;
+      line-height: 1.18;
       display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
       word-break: break-word;
     }
     .reward-card-inner .card-ext-skill-sub {
-      font-size: clamp(0.42rem, 7cqw, 0.6rem) !important;
-      line-height: 1.15;
+      font-size: clamp(0.5rem, 9cqw, 0.78rem) !important;
+      line-height: 1.18;
     }
     .reward-card-inner .card-effect-summary {
-      position: absolute; left: 0; right: 0; bottom: 0; height: 35%;
+      position: absolute; left: 0; right: 0; bottom: 0; height: 38%;
       border-radius: 0 0 8px 8px; overflow: hidden;
-      background: rgba(14,10,24,0.92); color: #e6e0f0;  /* ダーク化 (旧 #d8d0e4 を撤去) */
+      background: rgba(14,10,24,0.92); color: #e6e0f0;
       border-top: 1px solid rgba(255,255,255,0.08);
-      padding: 0.22rem 0.28rem;
-      font-size: clamp(0.5rem, 7.5cqw, 0.7rem); font-weight: 600;
+      padding: 0.28rem 0.32rem;
+      /* 効果テキストは最重要なので一段大きく */
+      font-size: clamp(0.7rem, 12.5cqw, 1.0rem); font-weight: 700;
       line-height: 1.28; text-align: left; z-index: 6;
     }
-    .reward-card-inner .card-effect-summary p { margin: 0.06rem 0; }
+    .reward-card-inner .card-effect-summary p { margin: 0.08rem 0; }
     /* container query 用 */
     .reward-card-inner { container-type: inline-size; }
 
@@ -1608,13 +1609,17 @@
       height: auto; aspect-ratio: 7 / 12;
       border-width: 3px;  /* レアリティ枠線をやや太く */
     }
-    /* デッキ表示中のカード名フォントは、コンテナ幅に応じて自動縮小 */
+    /* デッキ表示は密度が高いがフォントは可能な範囲で大きく。
+       cqw 上下限を引き上げ、効果テキストを優先して読みやすく */
     .owned-deck-cell .reward-card-inner .card-ext-name {
-      font-size: clamp(0.42rem, 7.5cqw, 0.62rem);
+      font-size: clamp(0.55rem, 10.5cqw, 0.82rem);
       -webkit-line-clamp: 2;
     }
+    .owned-deck-cell .reward-card-inner .card-ext-skill-sub {
+      font-size: clamp(0.46rem, 8.5cqw, 0.7rem) !important;
+    }
     .owned-deck-cell .reward-card-inner .card-effect-summary {
-      font-size: clamp(0.46rem, 7cqw, 0.64rem);
+      font-size: clamp(0.6rem, 12cqw, 0.88rem);
     }
     .owned-deck-peek {
       position: fixed; inset: 0; z-index: 560;

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -619,15 +619,17 @@
       line-height: 1.2;
     }
     /* Target badge side colors (#44 SPEC-005 Phase 1) */
-    .card-user-br.tgt-self  { color: #FDCB6E; border-color: #FDCB6E; }
-    .card-user-br.tgt-ally  { color: #4DA3F0; border-color: #4DA3F0; }
-    .card-user-br.tgt-enemy { color: #ff8090; border-color: #d63031; }
-    .card-user-br.tgt-all   { color: #c8b6e6; border-color: #6f5fa6; }
-    /* reward-card 上での位置調整（reward-card-inner は別レイアウト） */
+    .card-user-br.tgt-self  { color: #2ecc71; border-color: #2ecc71; }  /* 自身 = 緑 (味方扱い) */
+    .card-user-br.tgt-ally  { color: #2ecc71; border-color: #2ecc71; }  /* 味方 = 緑 */
+    .card-user-br.tgt-enemy { color: #ff8090; border-color: #d63031; }  /* 敵 = 赤 */
+    .card-user-br.tgt-all   { color: #c8b6e6; border-color: #6f5fa6; }  /* 全 = 紫 */
+    /* reward-card 上は cost-badge の右側、ヘッダー寄りに配置 (見切れ回避) */
     .reward-card-inner .card-user-br {
-      bottom: 6px; right: 6px;
-      z-index: 3;
-      font-size: 0.62rem; padding: 2px 6px;
+      bottom: auto; right: 0.22rem;
+      top: 0.32rem;
+      z-index: 8;
+      font-size: 0.58rem; padding: 1px 5px;
+      background: rgba(10,8,18,0.88);
     }
     .card-effect-area {
       background: #d8d0e4; color: #1a1420;
@@ -922,18 +924,29 @@
     }
     .reward-card-inner .card-ext-name {
       position: absolute; left: 0.22rem; right: 0.22rem; bottom: 35%; z-index: 7;
-      font-size: clamp(0.52rem,2.6vw,calc(0.58rem + 4px)); font-weight: 700;
+      /* container query: クエリ可能なら親幅基準 (cqw)、不可なら従来 (vw) */
+      font-size: clamp(0.46rem, 8.5cqw, 0.7rem); font-weight: 700;
       color: var(--text); text-shadow: 0 1px 3px #000c;
+      line-height: 1.15;
       display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+      word-break: break-word;
+    }
+    .reward-card-inner .card-ext-skill-sub {
+      font-size: clamp(0.42rem, 7cqw, 0.6rem) !important;
+      line-height: 1.15;
     }
     .reward-card-inner .card-effect-summary {
       position: absolute; left: 0; right: 0; bottom: 0; height: 35%;
       border-radius: 0 0 8px 8px; overflow: hidden;
-      background: #d8d0e4; color: #1a1420;
-      padding: 0.22rem 0.28rem; font-size: calc(0.52rem + 6px); font-weight: 700;
+      background: rgba(14,10,24,0.92); color: #e6e0f0;  /* ダーク化 (旧 #d8d0e4 を撤去) */
+      border-top: 1px solid rgba(255,255,255,0.08);
+      padding: 0.22rem 0.28rem;
+      font-size: clamp(0.5rem, 7.5cqw, 0.7rem); font-weight: 600;
       line-height: 1.28; text-align: left; z-index: 6;
     }
     .reward-card-inner .card-effect-summary p { margin: 0.06rem 0; }
+    /* container query 用 */
+    .reward-card-inner { container-type: inline-size; }
 
     /* Rarity border colors on reward / shop / craft cards */
     .reward-card-btn[data-rarity="common"]    .reward-card-inner { border-color: #0984E3; }
@@ -1464,6 +1477,11 @@
       display: flex; flex-wrap: wrap; gap: 0.65rem;
       justify-content: center; margin: 0.6rem 0;
     }
+    /* reward-card-btn が width:100% で 1 列化していたのを上書き、横並び flex-wrap が機能するように */
+    .craft-reward-list .reward-card-btn {
+      flex: 0 0 auto; width: auto;
+      max-width: calc(var(--card-w, 112px) + 4px);
+    }
     .craft-upgrade-list {
       display: flex; flex-direction: row; flex-wrap: wrap;
       gap: 0.65rem; margin: 0.6rem 0; justify-content: center;
@@ -1588,6 +1606,15 @@
     .owned-deck-cell .reward-card-inner {
       width: 100%; min-width: 0; max-width: 100%;
       height: auto; aspect-ratio: 7 / 12;
+      border-width: 3px;  /* レアリティ枠線をやや太く */
+    }
+    /* デッキ表示中のカード名フォントは、コンテナ幅に応じて自動縮小 */
+    .owned-deck-cell .reward-card-inner .card-ext-name {
+      font-size: clamp(0.42rem, 7.5cqw, 0.62rem);
+      -webkit-line-clamp: 2;
+    }
+    .owned-deck-cell .reward-card-inner .card-effect-summary {
+      font-size: clamp(0.46rem, 7cqw, 0.64rem);
     }
     .owned-deck-peek {
       position: fixed; inset: 0; z-index: 560;
@@ -1958,12 +1985,17 @@
       font-size: 0.74rem; color: #c8e8f0; margin-bottom: 1rem;
       animation: ll-skill-appear 0.4s 0.2s ease both;
     }
-    /* card skill subtitle */
+    /* card skill subtitle (battle hand) — 横幅に応じて自動縮小、見切れ防止 */
     .card-skill-sub {
-      font-size: 0.6rem; color: #7de8f8; opacity: 0.85;
+      font-size: clamp(0.42rem, 6.5cqw, 0.6rem);
+      color: #7de8f8; opacity: 0.85;
       display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
       margin-top: 1px;
+      line-height: 1.15;
     }
+    /* card-name-hd を container にして子要素が % 単位を取れるよう */
+    .card-name-hd { container-type: inline-size; }
+    .card-name-hd { font-size: clamp(0.5rem, 7.5cqw, 0.62rem); }
     .card-ext-skill-sub {
       font-size: 0.62rem; color: #7de8f8; opacity: 0.9;
       margin-top: 2px; display: block;

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -618,6 +618,17 @@
       border-radius: 4px; padding: 1px 4px; color: var(--muted);
       line-height: 1.2;
     }
+    /* Target badge side colors (#44 SPEC-005 Phase 1) */
+    .card-user-br.tgt-self  { color: #FDCB6E; border-color: #FDCB6E; }
+    .card-user-br.tgt-ally  { color: #4DA3F0; border-color: #4DA3F0; }
+    .card-user-br.tgt-enemy { color: #ff8090; border-color: #d63031; }
+    .card-user-br.tgt-all   { color: #c8b6e6; border-color: #6f5fa6; }
+    /* reward-card 上での位置調整（reward-card-inner は別レイアウト） */
+    .reward-card-inner .card-user-br {
+      bottom: 6px; right: 6px;
+      z-index: 3;
+      font-size: 0.62rem; padding: 2px 6px;
+    }
     .card-effect-area {
       background: #d8d0e4; color: #1a1420;
       padding: 0.18rem 0.24rem; font-size: 0.58rem;

--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -65,6 +65,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 50, 60);
         return [`敵にダメージ　${d}`];
@@ -88,6 +89,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estIntHit(s.playerInt, s.enemyInt, 25, 30);
         return [`敵にダメージ　${d}`, "INT　−2（敵）"];
@@ -115,6 +117,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "hp.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines(s) {
         const lo = estHealInt(s.playerInt, s.playerPhy, 30, 30);
         const hi = estHealInt(s.playerInt, s.playerPhy, 40, 40);
@@ -140,6 +143,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_phy.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() {
         return ["PHY　+2", "ガード　+7"];
       },
@@ -165,6 +169,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_agi.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() {
         return ["AGI　+3", "ガード　+3", "次ターン ⚡　+1"];
       },
@@ -195,6 +200,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 45, 55);
         return [`敵にダメージ　${d}`];
@@ -218,6 +224,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "skl",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estIntHit(s.playerInt + 1, s.enemyInt, 15, 20);
         return ["INT　+1", "ドロー　2", `敵にダメージ　${d}`];
@@ -249,6 +256,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 45, 55);
         return [`敵にダメージ　${d}`];
@@ -272,6 +280,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 40, 40);
         const agiDown = Math.max(1, Math.floor(s.playerPhy * 0.03));
@@ -302,6 +311,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estIntHit(s.playerInt, s.enemyInt, 15, 20);
         const intDown = Math.max(1, Math.floor(s.playerInt * 0.06));
@@ -336,6 +346,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 30, 40);
         const selfDown = Math.max(1, Math.floor(s.playerPhy * 0.09));
@@ -370,6 +381,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 65, 80);
         return [`敵にダメージ　${d}`];
@@ -393,6 +405,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estIntHit(s.playerInt, s.enemyInt, 35, 45);
         return [`敵にダメージ　${d}`, "INT　−3（敵）"];
@@ -420,6 +433,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_phy.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() {
         return ["PHY　+3", "ガード　+12"];
       },
@@ -445,6 +459,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 60, 75);
         return [`敵にダメージ　${d}`];
@@ -468,6 +483,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 60, 75);
         return [`敵にダメージ　${d}`];
@@ -491,6 +507,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 55, 70);
         return [`敵にダメージ　${d}`];
@@ -515,6 +532,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "hp.png",
       cost: 0,
       type: "skl",
+      target: "self",
       exhaust: true,
       effectSummaryLines(s) {
         const h = Math.floor((s.playerInt + s.playerPhy) / 2);
@@ -541,6 +559,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_agi.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["ガード　+8", "AGI　+2（永続）"]; },
       peekHelpKeys() { return ["guard", "agi"]; },
       previewLines() { return ["ガードを 8 得る", "AGI を +2（永続）"]; },
@@ -559,6 +578,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["INT　+2（永続）", "ドロー　3"]; },
       peekHelpKeys() { return ["int", "draw"]; },
       previewLines() { return ["INT を +2（永続）", "カードを 3 枚引く"]; },
@@ -581,6 +601,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 100, 100);
         return [`敵にダメージ　${d}`];
@@ -601,6 +622,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 2,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 70, 70);
         return [`敵にダメージ　${d} ×2`];
@@ -624,6 +646,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_phy.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["ガード　+6"]; },
       peekHelpKeys() { return ["guard"]; },
       previewLines() { return ["ガードを 6 得る（このターン中 PHY/INT ダメージ軽減）"]; },
@@ -642,6 +665,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["⚡ +1（このターン）"]; },
       peekHelpKeys() { return ["energy"]; },
       previewLines() { return ["このターンのエナジーを 1 増やす"]; },
@@ -660,6 +684,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 2,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 150, 150);
         return [`敵にダメージ　${d}`];
@@ -680,6 +705,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_phy.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["PHY　+3（永続）"]; },
       peekHelpKeys() { return ["phy"]; },
       previewLines() { return ["PHY を +3（このランの残り全ての戦闘で有効）"]; },
@@ -698,6 +724,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "hp.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines(s) {
         const h = Math.floor((s.playerInt + s.playerPhy) / 2);
         return [`HP　+${h}`];
@@ -726,6 +753,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 0,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 60, 60);
         return [`敵にダメージ　${d}`, "次ターン PHY -3"];
@@ -753,6 +781,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       exhaust: true,
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 80, 80);
@@ -774,6 +803,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 60, 60);
         return [`敵にダメージ　${d}`, "出血　×1（敵）"];
@@ -797,6 +827,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_agi.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["ガード　+8", "AGI　+2（永続）"]; },
       peekHelpKeys() { return ["guard", "agi"]; },
       previewLines() {
@@ -818,6 +849,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "hp.png",
       cost: 0,
       type: "skl",
+      target: "self",
       exhaust: true,
       effectSummaryLines(s) {
         const h = Math.floor((s.playerInt + s.playerPhy) / 2);
@@ -845,6 +877,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 50, 50);
         return [`敵にダメージ　${d} ×2`];
@@ -868,6 +901,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 2,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["INT　+2（永続）", "ドロー　3"]; },
       peekHelpKeys() { return ["int", "draw"]; },
       previewLines() { return ["INT を +2（永続）", "カードを 3 枚引く"]; },
@@ -890,6 +924,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 60, 60);
         return [`敵にダメージ　${d}`, "毒　×2（敵）"];
@@ -913,6 +948,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 2,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 90, 90);
         return [`敵にダメージ　${d}`, "出血　×2（敵）"];
@@ -936,6 +972,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "hp.png",
       cost: 0,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["毒・出血 解除（自分）"]; },
       peekHelpKeys() { return []; },
       previewLines() { return ["自分の毒スタックと出血スタックをすべて解除する"]; },
@@ -950,6 +987,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_phy.png",
       cost: 2,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["ガード　+12"]; },
       peekHelpKeys() { return ["guard"]; },
       previewLines() { return ["ガードを 12 得る（このターン中 PHY/INT ダメージ軽減）"]; },
@@ -968,6 +1006,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estIntHit(s.playerInt, s.enemyInt, 50, 50);
         return [`敵にダメージ　${d} ×3`];
@@ -992,6 +1031,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 0,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["GUM　+20"]; },
       peekHelpKeys() { return []; },
       previewLines() { return ["ゴールド（GUM）を 20 得る"]; },
@@ -1009,6 +1049,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_agi.png",
       cost: 1,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["シールド　+10"]; },
       peekHelpKeys() { return ["shield"]; },
       previewLines() { return ["シールドを 10 得る（特殊ダメージのみ吸収）"]; },
@@ -1023,6 +1064,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "phy.png",
       cost: 3,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estPhyHit(s.playerPhy, s.enemyPhy, 200, 200);
         return [`敵にダメージ　${d}`];
@@ -1043,6 +1085,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_phy.png",
       cost: 2,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["PHY　+5", "INT　+5（永続）"]; },
       peekHelpKeys() { return ["phy", "int"]; },
       previewLines() { return ["PHY を +5、INT を +5（永続）"]; },
@@ -1062,6 +1105,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 2,
       type: "atk",
+      target: "enemy.foremost",
       effectSummaryLines(s) {
         const d = estIntHit(s.playerInt, s.enemyInt, 130, 130);
         return [`敵にダメージ　${d}`, "クリ確定"];
@@ -1082,6 +1126,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "BUF_agi.png",
       cost: 0,
       type: "skl",
+      target: "self",
       effectSummaryLines() { return ["被ダメージ ½（このターン）"]; },
       peekHelpKeys() { return ["guard"]; },
       previewLines() { return ["このターン（ターン終了まで）受けるダメージをすべて半減する"]; },

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -1488,6 +1488,50 @@ const PEEK_HELP_SNIPPETS = {
   hp:     "<strong>HP</strong> — 0 で敗北。回復は最大値を超えない。",
 };
 
+// ─── ターゲット表示バッジ (#44 SPEC-005 Phase 1) ──────────────────
+/**
+ * カードのターゲット仕様を表示用ラベル + サイドカラーに変換。
+ * Phase 3 で 3v3 ターゲット解決が動くまでは静的ラベル表示。
+ */
+const TARGET_BADGE_DEFS = {
+  "self":              { label: "自身",     side: "self"  },
+  "ally.foremost":     { label: "味方先頭", side: "ally"  },
+  "ally.rearmost":     { label: "味方後尾", side: "ally"  },
+  "ally.front":        { label: "前衛",     side: "ally"  },
+  "ally.mid":          { label: "中衛",     side: "ally"  },
+  "ally.back":         { label: "後衛",     side: "ally"  },
+  "ally.all":          { label: "味方全",   side: "ally"  },
+  "ally.random":       { label: "味方?",    side: "ally"  },
+  "ally.highest_phy":  { label: "PHY↑",   side: "ally"  },
+  "ally.lowest_phy":   { label: "PHY↓",   side: "ally"  },
+  "ally.highest_int":  { label: "INT↑",   side: "ally"  },
+  "ally.lowest_int":   { label: "INT↓",   side: "ally"  },
+  "ally.highest_hp":   { label: "HP↑",    side: "ally"  },
+  "ally.lowest_hp":    { label: "HP↓",    side: "ally"  },
+  "enemy.foremost":    { label: "敵先頭",  side: "enemy" },
+  "enemy.rearmost":    { label: "敵後尾",  side: "enemy" },
+  "enemy.front":       { label: "敵前衛",  side: "enemy" },
+  "enemy.mid":         { label: "敵中衛",  side: "enemy" },
+  "enemy.back":        { label: "敵後衛",  side: "enemy" },
+  "enemy.all":         { label: "敵全",    side: "enemy" },
+  "enemy.random":      { label: "敵?",     side: "enemy" },
+  "enemy.highest_phy": { label: "敵PHY↑", side: "enemy" },
+  "enemy.lowest_phy":  { label: "敵PHY↓", side: "enemy" },
+  "enemy.highest_int": { label: "敵INT↑", side: "enemy" },
+  "enemy.lowest_int":  { label: "敵INT↓", side: "enemy" },
+  "enemy.highest_hp":  { label: "敵HP↑",  side: "enemy" },
+  "enemy.lowest_hp":   { label: "敵HP↓",  side: "enemy" },
+  "all":               { label: "全",      side: "all"   },
+  "all.random":        { label: "全?",     side: "all"   },
+};
+function buildTargetBadgeHtml(card) {
+  const spec = (card && card.target) || "enemy.foremost"; // 後方互換
+  const def = TARGET_BADGE_DEFS[spec] || { label: spec, side: "all" };
+  return '<span class="card-user-br tgt-' + def.side + '" data-target="' + spec +
+    '" title="ターゲット: ' + escapeHtml(def.label) + '">' +
+    escapeHtml(def.label) + "</span>";
+}
+
 function buildPeekHelpHtml(keys) {
   if (!keys || !keys.length) return "";
   const parts = keys.map((k) => PEEK_HELP_SNIPPETS[k]).filter(Boolean);
@@ -1736,7 +1780,7 @@ function renderCombat() {
       '<div class="card-icon-area">' +
       '<img class="card-ext-img-full" src="' + EXT_IMG(card.extId) + '" alt="" onerror="this.style.opacity=\'0\'" />' +
       '<img class="card-skill-icon-tl" src="' + battleIconUrl(card.skillIcon) + '" alt="" />' +
-      '<span class="card-user-br">先頭</span>' +
+      buildTargetBadgeHtml(card) +
       '</div>' +
       '<div class="card-effect-area">' + summaryBody + '</div>' +
       '</div>' +
@@ -2024,6 +2068,7 @@ function buildRewardPickButton(def, mockS) {
     '<span class="card-cost-badge"><span class="cost-zeus" aria-hidden="true">⚡</span>' + def.cost + "</span>" +
     '<img class="card-skill-corner" src="' + battleIconUrl(def.skillIcon) + '" alt="" />' +
     "</div></div>" +
+    buildTargetBadgeHtml(def) +
     '<div class="card-ext-name">' + escapeHtml(def.extNameJa) +
     (def.skillNameJa ? '<span class="card-ext-skill-sub">' + escapeHtml(def.skillNameJa) + '</span>' : '') +
     "</div>" +


### PR DESCRIPTION
## Summary
β版に向けた SPEC-005「パーティ編成 3v3 + ターゲット指定システム」の起草と、その **Phase 1（=既存挙動を一切変えずに UX を改善する単独リリース可能な部分）** をまとめた PR。

α 公開中の現状にも単独で価値があるため、**β実装の一部としてではなく α 改善として main へ merge** することを想定。

## 含まれるコミット
1. `4813151` SPEC-005 起草（docs/specs/SPEC-005-party-3v3.md, 18 節）
2. `52d3530` 全 45 カードに `target` フィールド付与 + 戦闘 / プレビュー両方のカードに静的ターゲットバッジを表示
3. `6be402b` ターゲットバッジ表示位置と色 + カードスタイル微調整

## 表示変更（α への効果）
- カード上の旧固定「先頭」ラベル → ターゲット仕様に応じた動的表示
  - 攻撃カード: 「敵先頭」（赤）
  - 自己バフ系: 「自身」（緑）
  - 全体系（将来）: 「敵全」「全」（紫）
- デッキ表示 / クラフト / ショップでも同バッジが見える
- カード効果サマリーの背景を 白 → ダークに統一
- レアリティ枠線をやや太く
- カード名とスキル名サブが container query で自動縮小、見切れ防止
- クラフト取得画面の縦 1 列を横並びに

## 挙動変化
**なし**。play() 関数や戦闘ロジックには一切手を入れていません。target は表示用メタとしてのみ機能。3v3 戦闘や AI、パッシブ拡張は本 PR では未実装（後続 Phase 2-4 で別 PR 予定）。

## β に向けた次のステップ（マージ後）
- Phase 2: combat 構造の配列化（`combat.heroes[]` / `combat.enemies[]`、shim で 1v1 互換維持）
- Phase 3: パーティ編成画面 + 3v3 戦闘 UI + ターゲット解決アルゴリズム
- Phase 4: ヒーロー / エネミーパッシブ拡張（リザレクション系含む）
- Phase 5（post-β）: シミュレータ 3v3 対応

詳細は SPEC-005 §13。

## Test plan (α 上)
- [ ] バトル画面で各カードに陣営別の target バッジが見える
- [ ] デッキ表示 / クラフト / ショップでもバッジが見える
- [ ] カード名・スキル名が見切れていない
- [ ] クラフト取得画面が横並びに表示される
- [ ] 既存 1v1 戦闘の挙動が完全不変（クリア / 敗北 / レギュレーション解放等）

## 関連
- Issue: #44
- SPEC: docs/specs/SPEC-005-party-3v3.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)