### PR TITLE
fix(card-text): 「永続」表記を実態に合わせ「戦闘中ずっと」に + ヘルプ用語節

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -2442,6 +2442,7 @@
         <button type="button" class="help-nav-btn help-nav-btn--active" data-help-nav="goal" role="tab" aria-selected="true">目的</button>
         <button type="button" class="help-nav-btn" data-help-nav="controls" role="tab" aria-selected="false">操作</button>
         <button type="button" class="help-nav-btn" data-help-nav="params" role="tab" aria-selected="false">パラメーター</button>
+        <button type="button" class="help-nav-btn" data-help-nav="terms" role="tab" aria-selected="false">用語</button>
         <button type="button" class="help-nav-btn" data-help-nav="battle" role="tab" aria-selected="false">バトル</button>
       </div>
       <div class="help-body">
@@ -2484,6 +2485,29 @@
             <li><strong>✦ シールド</strong> — <strong>特殊ダメージ</strong>（最大 HP 割合など）だけを先に吸収します。PHY/INT 通常攻撃には効きません。</li>
           </ul>
           <p>詳しい原作の定義は <a href="https://www.mycryptoheroes.net/ja/help-posts/7iMLBLL1sMJ9Rlk2Fv2Zmj" target="_blank" rel="noopener">MCH ヘルプ：パラメーター</a> を参照してください。</p>
+        </section>
+        <section class="help-page" data-help-page="terms">
+          <h3>カードに出てくる用語</h3>
+          <ul>
+            <li><strong>戦闘中ずっと</strong> — その効果は<strong>そのバトルが終わるまで</strong>続きます。次のバトルでは元の値に戻ります（例: <code>PHY +3（戦闘中ずっと）</code>）。</li>
+            <li><strong>【消耗】</strong> — 使用後、そのカードは<strong>除外</strong>され、残りデッキ・捨て札に戻りません（例: エリートペン）。</li>
+            <li><strong>ガード +N</strong> — そのターン中に受ける PHY/INT ダメージを N 分先に削る軽減層。<strong>ターン開始でリセット</strong>されます。</li>
+            <li><strong>シールド +N</strong> — 特殊ダメージ（最大 HP 割合等）のみ吸収。PHY/INT 通常攻撃には<strong>効きません</strong>。リセットなし。</li>
+            <li><strong>ドロー N</strong> — 山札から N 枚カードを引きます。山札が空のときは捨て札を切り直してから引きます。</li>
+            <li><strong>毒 ×N</strong> — 各ターン開始時に N ダメージ。スタック数だけ繰り返し効きます。</li>
+            <li><strong>出血 ×N</strong> — そのユニットがカードを使う / 行動するたびに N ダメージ。スタックする。</li>
+          </ul>
+          <h3>カードのターゲット表示（右上の色付きラベル）</h3>
+          <ul>
+            <li><strong style="color:#ff8090">敵先頭</strong>（赤）— その時点で生存している<strong>最も画面中央寄りの敵</strong>。前衛 → 中衛 → 後衛 の順に見ます。</li>
+            <li><strong style="color:#ff8090">敵全</strong>（赤）— 生存している敵全員に効果を適用。</li>
+            <li><strong style="color:#2ecc71">自身</strong>（緑）— カードを使ったヒーロー自身に効果を適用。</li>
+            <li><strong style="color:#2ecc71">味方先頭 / 味方全</strong>（緑）— 味方パーティ側の対象。</li>
+            <li><strong style="color:#c8b6e6">全</strong>（紫）— 敵味方すべて。</li>
+            <li><strong>?</strong> — ランダム（その時点の生存者から無作為に選択）。</li>
+            <li><strong>PHY↑ / HP↓</strong> 等 — そのステータスが<strong>最も高い / 低い</strong>対象を選択。</li>
+          </ul>
+          <p style="font-size:0.78rem;color:var(--muted)">※ パーティ編成（3 人 vs 3 人）はベータ版で実装予定。アルファ版では実質 1 体ずつのため、上記ラベルは <strong>誰に効くか</strong>の予告として機能します。</p>
         </section>
         <section class="help-page" data-help-page="battle">
           <h3>バトルロジック（概要）</h3>

--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -560,9 +560,9 @@ function makeCardLibrary(clog, api) {
       cost: 1,
       type: "skl",
       target: "self",
-      effectSummaryLines() { return ["ガード　+8", "AGI　+2（永続）"]; },
+      effectSummaryLines() { return ["ガード　+8", "AGI　+2（戦闘中ずっと）"]; },
       peekHelpKeys() { return ["guard", "agi"]; },
-      previewLines() { return ["ガードを 8 得る", "AGI を +2（永続）"]; },
+      previewLines() { return ["ガードを 8 得る", "AGI を +2（戦闘中ずっと）"]; },
       play(s) {
         se("buff"); fx("player", "buff");
         s.playerGuard += 8;
@@ -579,9 +579,9 @@ function makeCardLibrary(clog, api) {
       cost: 1,
       type: "skl",
       target: "self",
-      effectSummaryLines() { return ["INT　+2（永続）", "ドロー　3"]; },
+      effectSummaryLines() { return ["INT　+2（戦闘中ずっと）", "ドロー　3"]; },
       peekHelpKeys() { return ["int", "draw"]; },
-      previewLines() { return ["INT を +2（永続）", "カードを 3 枚引く"]; },
+      previewLines() { return ["INT を +2（戦闘中ずっと）", "カードを 3 枚引く"]; },
       play(s) {
         se("buff"); fx("player", "buff");
         s.playerInt += 2;
@@ -706,9 +706,9 @@ function makeCardLibrary(clog, api) {
       cost: 1,
       type: "skl",
       target: "self",
-      effectSummaryLines() { return ["PHY　+3（永続）"]; },
+      effectSummaryLines() { return ["PHY　+3（戦闘中ずっと）"]; },
       peekHelpKeys() { return ["phy"]; },
-      previewLines() { return ["PHY を +3（このランの残り全ての戦闘で有効）"]; },
+      previewLines() { return ["PHY を +3（戦闘中ずっと。次の戦闘では戻る）"]; },
       play(s) {
         se("buff"); fx("player", "buff");
         s.playerPhy += 3;
@@ -828,10 +828,10 @@ function makeCardLibrary(clog, api) {
       cost: 1,
       type: "skl",
       target: "self",
-      effectSummaryLines() { return ["ガード　+8", "AGI　+2（永続）"]; },
+      effectSummaryLines() { return ["ガード　+8", "AGI　+2（戦闘中ずっと）"]; },
       peekHelpKeys() { return ["guard", "agi"]; },
       previewLines() {
-        return ["ガードを 8 得る", "AGI を +2（永続）"];
+        return ["ガードを 8 得る", "AGI を +2（戦闘中ずっと）"];
       },
       play(s) {
         se("buff"); fx("player", "buff");
@@ -902,9 +902,9 @@ function makeCardLibrary(clog, api) {
       cost: 2,
       type: "skl",
       target: "self",
-      effectSummaryLines() { return ["INT　+2（永続）", "ドロー　3"]; },
+      effectSummaryLines() { return ["INT　+2（戦闘中ずっと）", "ドロー　3"]; },
       peekHelpKeys() { return ["int", "draw"]; },
-      previewLines() { return ["INT を +2（永続）", "カードを 3 枚引く"]; },
+      previewLines() { return ["INT を +2（戦闘中ずっと）", "カードを 3 枚引く"]; },
       play(s) {
         se("buff"); fx("player", "buff");
         s.playerInt += 2;
@@ -1086,9 +1086,9 @@ function makeCardLibrary(clog, api) {
       cost: 2,
       type: "skl",
       target: "self",
-      effectSummaryLines() { return ["PHY　+5", "INT　+5（永続）"]; },
+      effectSummaryLines() { return ["PHY　+5", "INT　+5（戦闘中ずっと）"]; },
       peekHelpKeys() { return ["phy", "int"]; },
-      previewLines() { return ["PHY を +5、INT を +5（永続）"]; },
+      previewLines() { return ["PHY を +5、INT を +5（戦闘中ずっと）"]; },
       play(s) {
         se("buff"); fx("player", "buff");
         s.playerPhy += 5;


### PR DESCRIPTION
## Summary
ユーザーから「エリートアーマーの『永続』が何を示すのか分かりにくい」との指摘を受け、表記を実態に合わせ、ヘルプを補強。

## 調査
\"（永続）\" を持つカード（ext2005 / ext2008 / cd106 / cd204 / cd303 / cdH03 / cdH06 など）は、実装上 \`s.playerPhy += N\` のように **combat state にのみ加算**。combat はバトル毎に作り直されるため、**実態は「そのバトル中だけ」** で、ラン全体には持ち越されない。

cd106 では previewLines が「このランの残り全ての戦闘で有効」と、さらに誤った説明になっていた。

## 修正
1. **cards.js**: \"（永続）\" を全て \"（戦闘中ずっと）\" に置換 (12 箇所)
2. **cards.js**: cd106 の「このランの残り全ての戦闘で有効」を「戦闘中ずっと。次の戦闘では戻る」に修正
3. **ヘルプ overlay**: nav に「用語」タブを新設し、以下を解説
   - 「戦闘中ずっと」「【消耗】」「ガード」「シールド」「ドロー」「毒」「出血」
   - カード右上のターゲット表示（陣営別の色 / 先頭・全・自身・PHY↑ 等）

## 採用しなかった選択肢
- **効果をラン全体に持ち越す**: バランス影響大。runState にバフを保持し、各 combat 開始時に転写する仕組みが必要。本 PR では実装せず、必要なら別 Issue で対応可能
- **「永続」のまま放置**: 表記と実態が乖離して継続的な混乱源になる

## Test plan
- [ ] エリートアーマー / エリートホース / エリートブック等で「戦闘中ずっと」と表示される
- [ ] ヘルプ → 用語 タブが見える、内容が読める
- [ ] cd106 のプレビューで「戦闘中ずっと。次の戦闘では戻る」と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)