### PR TITLE
feat(beta phase2): targeting.js + combat.heroes[] / enemies[] の並行初期化（SPEC-005）

### DIFF
--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -34,6 +34,14 @@ import { CHAPTERS } from "./chapters.js";
 import { generateChapterMap } from "./maps.js";
 import { LL_EXT_POOL } from "./ll-extensions.js";
 import {
+  resolveTargets,
+  makeHeroUnit,
+  makeEnemyUnit,
+  foremostAlive,
+  rearmostAlive,
+  aliveAt,
+} from "./targeting.js";
+import {
   REGULATIONS,
   REGULATION_BY_ID,
   loadUnlockedRegulations,
@@ -1297,6 +1305,32 @@ function startCombatFromMapNode(node) {
     hasResurrection: false,
     _lastUi: null,
   };
+
+  // SPEC-005 Phase 2: heroes[] / enemies[] を並行で初期化（Phase 3 で正式に使用、現状は表示・解決用の参照のみ）
+  combat.heroes = [makeHeroUnit({
+    position: 0,
+    defId: LEADER.heroId,
+    name: LEADER.nameJa,
+    imgUrl: typeof LEADER.img === "function" ? LEADER.img() : null,
+    hp: combat.playerHp, hpMax: combat.playerHpMax,
+    phy: pPhy, int: pInt, agi: pAgi,
+    phyBase: pPhy, intBase: pInt, agiBase: pAgi,
+    passiveKey: LEADER.passiveKey || null,
+  })];
+  combat.enemies = [makeEnemyUnit({
+    position: 0,
+    defId: enemyDef.id,
+    name: enemyDef.name,
+    imgId: enemyDef.imgId,
+    hp: regHp, hpMax: regHp,
+    phy: regPhy, int: regInt, agi: enemyDef.agi,
+    phyBase: regPhy, intBase: regInt, agiBase: enemyDef.agi,
+    shield: enemyDef.initialShield || 0,
+    intentRota,
+    bossPhase, bossDef: isBoss ? bossDef : null,
+    isBoss,
+  })];
+  combat.activeHeroIdx = 0;
 
   combat.drawPile = shuffle(combat.deck.map((c) => copyCard(c.libraryKey)));
   showView("combat");

--- a/prototype/js/targeting.js
+++ b/prototype/js/targeting.js
@@ -1,0 +1,176 @@
+/**
+ * targeting.js — ターゲット解決の純粋関数群 (SPEC-005 Phase 2)
+ *
+ * カードに付与された target 仕様 (e.g. "enemy.foremost") を、
+ * 戦闘状態 (combat.heroes / combat.enemies) からユニット配列へ解決する。
+ *
+ * このモジュールは副作用を持たず、document / 外部状態にも触らない。
+ * Phase 3 で 3v3 UI / カードキャスト処理に組み込まれる。
+ */
+
+/**
+ * 指定ポジションで生存しているユニットを返す。
+ * @param {Unit[]} party 同陣営の配列（最大 3）
+ * @param {0|1|2} position
+ * @returns {Unit|null}
+ */
+export function aliveAt(party, position) {
+  if (!Array.isArray(party)) return null;
+  for (const u of party) {
+    if (u && u.position === position && u.alive !== false && (u.hp == null || u.hp > 0)) return u;
+  }
+  return null;
+}
+
+/** 前衛 → 中衛 → 後衛 の順で最初に生存しているユニット */
+export function foremostAlive(party) {
+  for (let p = 0; p < 3; p++) {
+    const u = aliveAt(party, p);
+    if (u) return u;
+  }
+  return null;
+}
+
+/** 後衛 → 中衛 → 前衛 の順で最初に生存しているユニット */
+export function rearmostAlive(party) {
+  for (let p = 2; p >= 0; p--) {
+    const u = aliveAt(party, p);
+    if (u) return u;
+  }
+  return null;
+}
+
+/** ランダム 1 体（rng が無ければ Math.random） */
+export function pickRandomAlive(party, rng) {
+  const alive = (party || []).filter(u => u && u.alive !== false && (u.hp == null || u.hp > 0));
+  if (alive.length === 0) return null;
+  const r = typeof rng === "function" ? rng() : Math.random();
+  return alive[Math.floor(r * alive.length)];
+}
+
+/** 与えた集計関数で最大値を持つユニット 1 体（同値時は先頭） */
+export function pickByMax(party, fn) {
+  let best = null, bestVal = -Infinity;
+  for (const u of (party || [])) {
+    if (!u || u.alive === false || (u.hp != null && u.hp <= 0)) continue;
+    const v = fn(u);
+    if (v > bestVal) { best = u; bestVal = v; }
+  }
+  return best;
+}
+
+/** 与えた集計関数で最小値を持つユニット 1 体（同値時は先頭） */
+export function pickByMin(party, fn) {
+  let best = null, bestVal = Infinity;
+  for (const u of (party || [])) {
+    if (!u || u.alive === false || (u.hp != null && u.hp <= 0)) continue;
+    const v = fn(u);
+    if (v < bestVal) { best = u; bestVal = v; }
+  }
+  return best;
+}
+
+/**
+ * ターゲット仕様を解決し、ユニット配列を返す。
+ * @param {string} spec - SPEC-005 §6 の語彙文字列
+ * @param {Unit} caster - カードを使うキャスター
+ * @param {{heroes:Unit[], enemies:Unit[], rng?:Function}} ctx
+ * @returns {Unit[]} 0〜N 体（解決不可なら空配列）
+ */
+export function resolveTargets(spec, caster, ctx) {
+  if (!spec) return [];
+  const heroes = (ctx && ctx.heroes) || [];
+  const enemies = (ctx && ctx.enemies) || [];
+  const myParty = caster && caster.side === "enemy" ? enemies : heroes;
+  const enemyParty = caster && caster.side === "enemy" ? heroes : enemies;
+  const rng = ctx && ctx.rng;
+
+  switch (spec) {
+    case "self": return caster ? [caster] : [];
+
+    case "ally.front":   return [aliveAt(myParty, 0)].filter(Boolean);
+    case "ally.mid":     return [aliveAt(myParty, 1)].filter(Boolean);
+    case "ally.back":    return [aliveAt(myParty, 2)].filter(Boolean);
+    case "ally.foremost":return [foremostAlive(myParty)].filter(Boolean);
+    case "ally.rearmost":return [rearmostAlive(myParty)].filter(Boolean);
+    case "ally.all":     return myParty.filter(u => u && u.alive !== false && (u.hp == null || u.hp > 0));
+    case "ally.random":  return [pickRandomAlive(myParty, rng)].filter(Boolean);
+    case "ally.highest_phy": return [pickByMax(myParty, u => u.phy ?? 0)].filter(Boolean);
+    case "ally.lowest_phy":  return [pickByMin(myParty, u => u.phy ?? 0)].filter(Boolean);
+    case "ally.highest_int": return [pickByMax(myParty, u => u.int ?? 0)].filter(Boolean);
+    case "ally.lowest_int":  return [pickByMin(myParty, u => u.int ?? 0)].filter(Boolean);
+    case "ally.highest_hp":  return [pickByMax(myParty, u => u.hp ?? 0)].filter(Boolean);
+    case "ally.lowest_hp":   return [pickByMin(myParty, u => u.hp ?? 0)].filter(Boolean);
+
+    case "enemy.front":   return [aliveAt(enemyParty, 0)].filter(Boolean);
+    case "enemy.mid":     return [aliveAt(enemyParty, 1)].filter(Boolean);
+    case "enemy.back":    return [aliveAt(enemyParty, 2)].filter(Boolean);
+    case "enemy.foremost":return [foremostAlive(enemyParty)].filter(Boolean);
+    case "enemy.rearmost":return [rearmostAlive(enemyParty)].filter(Boolean);
+    case "enemy.all":     return enemyParty.filter(u => u && u.alive !== false && (u.hp == null || u.hp > 0));
+    case "enemy.random":  return [pickRandomAlive(enemyParty, rng)].filter(Boolean);
+    case "enemy.highest_phy": return [pickByMax(enemyParty, u => u.phy ?? 0)].filter(Boolean);
+    case "enemy.lowest_phy":  return [pickByMin(enemyParty, u => u.phy ?? 0)].filter(Boolean);
+    case "enemy.highest_int": return [pickByMax(enemyParty, u => u.int ?? 0)].filter(Boolean);
+    case "enemy.lowest_int":  return [pickByMin(enemyParty, u => u.int ?? 0)].filter(Boolean);
+    case "enemy.highest_hp":  return [pickByMax(enemyParty, u => u.hp ?? 0)].filter(Boolean);
+    case "enemy.lowest_hp":   return [pickByMin(enemyParty, u => u.hp ?? 0)].filter(Boolean);
+
+    case "all":          return [...heroes, ...enemies].filter(u => u && u.alive !== false && (u.hp == null || u.hp > 0));
+    case "all.random":   {
+      const all = [...heroes, ...enemies].filter(u => u && u.alive !== false && (u.hp == null || u.hp > 0));
+      return [pickRandomAlive(all, rng)].filter(Boolean);
+    }
+
+    default:
+      // 未知の仕様 → 安全のため敵先頭に fallback
+      return [foremostAlive(enemyParty)].filter(Boolean);
+  }
+}
+
+/**
+ * Unit を新規生成するファクトリ（ヒーロー / エネミー共通の最小スキーマ）。
+ * 既存の startCombatFromMapNode の中で使い、combat.heroes / combat.enemies に積む。
+ */
+export function makeHeroUnit(opts) {
+  return {
+    side: "hero",
+    position: opts.position ?? 0,
+    alive: true,
+    defId: opts.defId,
+    name: opts.name,
+    imgUrl: opts.imgUrl,
+    hp: opts.hp, hpMax: opts.hpMax,
+    phy: opts.phy, int: opts.int, agi: opts.agi,
+    phyBase: opts.phyBase ?? opts.phy,
+    intBase: opts.intBase ?? opts.int,
+    agiBase: opts.agiBase ?? opts.agi,
+    guard: 0, shield: 0, poison: 0, bleed: 0, vulnerable: 0,
+    passiveKey: opts.passiveKey || null,
+    passiveTriggered: false,
+  };
+}
+
+export function makeEnemyUnit(opts) {
+  return {
+    side: "enemy",
+    position: opts.position ?? 0,
+    alive: true,
+    defId: opts.defId,
+    name: opts.name,
+    imgId: opts.imgId,
+    hp: opts.hp, hpMax: opts.hpMax,
+    phy: opts.phy, int: opts.int, agi: opts.agi,
+    phyBase: opts.phyBase ?? opts.phy,
+    intBase: opts.intBase ?? opts.int,
+    agiBase: opts.agiBase ?? opts.agi,
+    guard: 0, shield: opts.shield || 0,
+    poison: 0, bleed: 0, vulnerable: 0,
+    intentRota: opts.intentRota || [],
+    intentRotaIdx: 0,
+    enemyIntent: null,
+    bossPhase: opts.bossPhase ?? -1,
+    bossDef: opts.bossDef || null,
+    isBoss: !!opts.isBoss,
+  };
+}


### PR DESCRIPTION
## Summary
SPEC-005 Phase 2 = **3v3 戦闘の足場作り**。挙動は完全に既存と同一（並行データのみ追加、既存コード読み取りパスは不変）。

## 含まれる変更

### 新規ファイル: \`prototype/js/targeting.js\`
- \`resolveTargets(spec, caster, ctx)\` — SPEC-005 §6 の全語彙に対応
  - self / ally.front,mid,back / ally.foremost,rearmost / ally.all / ally.random / ally.highest_*,lowest_*
  - enemy.* 同上
  - all / all.random
  - 未知 spec → 安全に enemy.foremost にフォールバック
- ヘルパ: \`aliveAt\` / \`foremostAlive\` / \`rearmostAlive\` / \`pickRandomAlive\` / \`pickByMax\` / \`pickByMin\`
- ファクトリ: \`makeHeroUnit\` / \`makeEnemyUnit\`
- **純粋関数のみ**。document / 外部状態に触らない

### main.js 統合
- targeting.js から関数を import
- \`startCombatFromMapNode\` 末尾で \`combat.heroes\` / \`combat.enemies\` を並行初期化（既存の \`playerXxx\` / \`enemyXxx\` と同じ値）
- \`combat.activeHeroIdx = 0\` 追加

## 挙動変化
**なし**。既存コードは引き続き \`combat.playerHp\` 等を読み書きし、戦闘・AI・被ダメ・勝敗判定すべて従来通り。\`combat.heroes[0]\` / \`combat.enemies[0]\` は読み取り専用ミラーとして待機状態。

## 次の Phase
**Phase 3** で:
- パーティ編成画面（最大 3 ヒーロー）
- 3v3 戦闘 UI レイアウト
- アクティブキャスター切替
- カードキャスト時に resolveTargets を実際に使用
- 敵 AI のターゲット選択

## Test plan
- [ ] 既存 1v1 戦闘の挙動が完全不変（クリア・敗北・レギュレーション解放等）
- [ ] エラーなく初期化される（コンソールエラーなし）
- [ ] combat.heroes[0].hp が runState.playerHp と一致

## 関連
- Issue: #44
- SPEC: docs/specs/SPEC-005-party-3v3.md (§6, §7, §8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)