### PR TITLE
Phase 1: 元タイトル小ネタ盛り込み（通貨/イベント/スカウト/レイド/JIN/焼却/実績）

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -2131,6 +2131,8 @@
   <div class="wrap">
     <div class="resources" id="mapResources" aria-label="ランリソース">
       <span class="res"><img alt="GUM" data-icon="gum" /> <span id="goldVal">0</span></span>
+      <span class="res" title="MCHC：エリート/ボスでドロップ。ボス前の特殊ショップで Legendary 枠と交換できます" id="mchcRes">💠 <span id="mchcVal">0</span><span style="opacity:0.6;font-size:0.8em">&nbsp;MCHC</span></span>
+      <span class="res" title="Cp：休憩・クラフトで貯まる。打ち直し（クラフト）に使用" id="cpRes"><img alt="Cp" data-icon="cp" /> <span id="cpVal">0</span></span>
       <span class="res res-hp">♥ <span id="mapHpVal">0</span>/<span id="mapHpMax">0</span></span>
       <span class="res">層 <span id="layerVal">入口</span></span>
       <span class="res">章 <span id="chapterVal">1</span></span>

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -2311,6 +2311,8 @@
 
     <div id="craftView" class="hidden"></div>
 
+    <div id="eventView" class="panel hidden"></div>
+
     <div id="shopView" class="panel hidden">
       <div class="shop-header-row">
         <p style="margin:0;font-weight:600;color:var(--accent);font-size:0.95rem">ショップ</p>

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -2133,6 +2133,7 @@
       <span class="res"><img alt="GUM" data-icon="gum" /> <span id="goldVal">0</span></span>
       <span class="res" title="MCHC：エリート/ボスでドロップ。ボス前の特殊ショップで Legendary 枠と交換できます" id="mchcRes">💠 <span id="mchcVal">0</span><span style="opacity:0.6;font-size:0.8em">&nbsp;MCHC</span></span>
       <span class="res" title="Cp：休憩・クラフトで貯まる。打ち直し（クラフト）に使用" id="cpRes"><img alt="Cp" data-icon="cp" /> <span id="cpVal">0</span></span>
+      <span class="res" title="輝く原石：クラフトで ext を 2 枚 burn して入手。MCHC ショップ等で限定 ext と交換可能" id="stoneRes">💎 <span id="stoneVal">0</span></span>
       <span class="res res-hp">♥ <span id="mapHpVal">0</span>/<span id="mapHpMax">0</span></span>
       <span class="res">層 <span id="layerVal">入口</span></span>
       <span class="res">章 <span id="chapterVal">1</span></span>

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -2126,6 +2126,7 @@
     <img class="title-logo" src="./MCT_logo.jpg" alt="MyCryptoTactics" />
     <p class="title-alpha">アルファ版</p>
     <p class="title-press">Press to Start</p>
+    <button type="button" id="btnTitleAchievements" style="position:absolute;top:1rem;right:1rem;padding:0.5rem 1rem;background:rgba(0,0,0,0.6);color:#fff;border:1px solid var(--accent);border-radius:6px;cursor:pointer;font-size:0.9rem;z-index:10">🏆 実績</button>
   </div>
 
   <div class="wrap">

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -2313,6 +2313,8 @@
 
     <div id="eventView" class="panel hidden"></div>
 
+    <div id="scoutView" class="panel hidden"></div>
+
     <div id="shopView" class="panel hidden">
       <div class="shop-header-row">
         <p style="margin:0;font-weight:600;color:var(--accent);font-size:0.95rem">ショップ</p>

--- a/prototype/js/achievements.js
+++ b/prototype/js/achievements.js
@@ -1,0 +1,185 @@
+/**
+ * アチーブメント（実績）— localStorage で永続化。
+ * 元タイトル 2023 年 Achievement（トロフィー NFT）リリースのリスペクト。
+ *
+ * 解放はラン横断で記録され、タイトル画面の「実績」モーダルで一覧できる。
+ */
+
+const STORAGE_KEY = 'mct_achievements_v1';
+
+/** 実績マスタ */
+export const ACHIEVEMENTS = [
+  {
+    id: 'first-clear',
+    name: '初制覇',
+    desc: '全章をクリアする（諭吉組デビュー）',
+    icon: '🏆',
+  },
+  {
+    id: 'yoshiko-defeated',
+    name: 'よしこ討伐',
+    desc: '章間レイドのヨシュカを撃破する',
+    icon: '🍵',
+  },
+  {
+    id: 'yoshiko-choco-endured',
+    name: 'チョコ耐久勝利',
+    desc: 'ヨシュカ・チョコの 30 ターン耐久を凌ぎ「チョコ片」を入手する',
+    icon: '🍫',
+  },
+  {
+    id: 'jin-active',
+    name: '陣（JIN）発動',
+    desc: '1 ラン中に陣（JIN）を発動させる',
+    icon: '🪄',
+  },
+  {
+    id: 'shingen-clear',
+    name: 'ナーフ後でクリア',
+    desc: '武田信玄（ナーフ後）を含めたデッキで全章をクリアする',
+    icon: '⚖️',
+  },
+  {
+    id: 'scout-all-lands',
+    name: '9 ランド + 流星街 制覇',
+    desc: 'ラン横断で 10 ランドすべてを選択する',
+    icon: '🏳️',
+  },
+  {
+    id: 'mchc-shop-buy',
+    name: 'Eco 3.0 デビュー',
+    desc: 'MCHC ショップで Legendary 枠を解放する',
+    icon: '💠',
+  },
+  {
+    id: 'ema3-burn',
+    name: 'EMA3 デビュー',
+    desc: 'ext を焼却して輝く原石を入手する',
+    icon: '💎',
+  },
+];
+
+const ACHIEVEMENT_BY_ID = Object.fromEntries(ACHIEVEMENTS.map(a => [a.id, a]));
+
+/** localStorage から状態をロード（未解放配列＋ランド訪問履歴） */
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { unlocked: [], visitedLands: [] };
+    const parsed = JSON.parse(raw);
+    return {
+      unlocked: Array.isArray(parsed.unlocked) ? parsed.unlocked : [],
+      visitedLands: Array.isArray(parsed.visitedLands) ? parsed.visitedLands : [],
+    };
+  } catch {
+    return { unlocked: [], visitedLands: [] };
+  }
+}
+
+function saveState(state) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage が使えない場合は無視
+  }
+}
+
+/** 実績を解放。新規解放のときだけ true を返す */
+export function unlockAchievement(id) {
+  if (!ACHIEVEMENT_BY_ID[id]) return false;
+  const state = loadState();
+  if (state.unlocked.includes(id)) return false;
+  state.unlocked.push(id);
+  saveState(state);
+  return true;
+}
+
+/** 解放済みの実績 ID 一覧 */
+export function listUnlocked() {
+  return loadState().unlocked.slice();
+}
+
+/** 訪問済みランドを記録。新たに 10 国揃ったら 'scout-all-lands' を解放 */
+export function recordVisitedLand(landId) {
+  const state = loadState();
+  if (!state.visitedLands.includes(landId)) {
+    state.visitedLands.push(landId);
+    saveState(state);
+    if (state.visitedLands.length >= 10) {
+      unlockAchievement('scout-all-lands');
+    }
+  }
+}
+
+/** タイトル画面用：解放済みのトースト通知（DOM）を発火 */
+export function notifyUnlock(id) {
+  const def = ACHIEVEMENT_BY_ID[id];
+  if (!def) return;
+  if (typeof document === 'undefined') return;
+  const toast = document.createElement('div');
+  toast.style.cssText =
+    'position:fixed;top:1rem;right:1rem;background:rgba(20,20,30,0.95);border:1px solid var(--accent);' +
+    'border-radius:8px;padding:0.75rem 1rem;z-index:99999;color:#fff;font-size:0.9rem;' +
+    'box-shadow:0 4px 16px rgba(0,0,0,0.5);max-width:320px;animation:slideIn 0.3s ease-out;';
+  toast.innerHTML = `
+    <div style="font-weight:700;color:var(--accent);margin-bottom:0.25rem">${def.icon} 実績解放：${def.name}</div>
+    <div style="font-size:0.8rem;color:#bbb">${def.desc}</div>
+  `;
+  document.body.appendChild(toast);
+  setTimeout(() => {
+    toast.style.transition = 'opacity 0.5s';
+    toast.style.opacity = '0';
+    setTimeout(() => toast.remove(), 500);
+  }, 4000);
+}
+
+/** unlockAchievement + notifyUnlock を一括で */
+export function tryUnlock(id) {
+  if (unlockAchievement(id)) notifyUnlock(id);
+}
+
+/** 実績モーダルを開く（タイトル画面/設定からの呼び出し用） */
+export function openAchievementsModal() {
+  if (typeof document === 'undefined') return;
+  const overlay = document.createElement('div');
+  overlay.style.cssText =
+    'position:fixed;inset:0;background:rgba(0,0,0,0.85);display:flex;align-items:center;' +
+    'justify-content:center;z-index:9999;padding:1rem';
+  const card = document.createElement('div');
+  card.style.cssText =
+    'background:var(--bg);border:1px solid var(--accent);border-radius:8px;padding:1.5rem;' +
+    'max-width:520px;width:100%;max-height:90vh;overflow-y:auto';
+
+  const unlocked = new Set(listUnlocked());
+  card.innerHTML = `
+    <h2 style="margin:0 0 0.5rem;color:var(--accent)">🏆 実績（${unlocked.size}/${ACHIEVEMENTS.length}）</h2>
+    <p style="margin:0 0 0.75rem;font-size:0.85rem;color:var(--muted)">ラン横断で達成状況を記録します。</p>
+  `;
+  const list = document.createElement('div');
+  list.style.cssText = 'display:flex;flex-direction:column;gap:0.4rem;margin:0.5rem 0';
+  ACHIEVEMENTS.forEach(a => {
+    const isUnlocked = unlocked.has(a.id);
+    const row = document.createElement('div');
+    row.style.cssText =
+      `padding:0.5rem 0.75rem;background:var(--card-bg);border:1px solid var(--border);` +
+      `border-radius:6px;${isUnlocked ? '' : 'opacity:0.5'}`;
+    row.innerHTML = `
+      <div style="font-weight:700">${a.icon} ${a.name}${isUnlocked ? ' ✅' : ' 🔒'}</div>
+      <div style="font-size:0.8rem;color:var(--muted)">${a.desc}</div>
+    `;
+    list.appendChild(row);
+  });
+  card.appendChild(list);
+
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'action primary';
+  close.style.cssText = 'width:100%;margin-top:0.75rem';
+  close.textContent = '閉じる';
+  close.addEventListener('click', () => overlay.remove());
+  card.appendChild(close);
+
+  overlay.appendChild(card);
+  overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
+  document.body.appendChild(overlay);
+}

--- a/prototype/js/bosses.js
+++ b/prototype/js/bosses.js
@@ -73,6 +73,38 @@ export const BOSS_DEFS = {
       },
     ],
   },
+  // ─── 章間レイド ──────────────────────────────────────────────────
+  // 「ヨシュカ」初代レイド（弱すぎて1日で討伐された通称「よしこ」）の再現。
+  // 章1クリア後に幕間で出現。HP極小・火力激低。報酬は微妙な GUM のみ。
+  'boss-yoshiko': {
+    id: 'boss-yoshiko',
+    name: 'ヨシュカ（よしこ）',
+    hp: 18, phy: 4, int: 4, agi: 6, imgId: 171,
+    initialShield: 0,
+    intentRota: [
+      { kind: 'attack', phyPct: 50 },
+      { kind: 'guard', value: 4 },
+      { kind: 'attack', phyPct: 60 },
+    ],
+  },
+  // 「ヨシュカ・チョコ」2nd レイド（強すぎて時間切れまで倒し切れず）の再現。
+  // 章2クリア後の幕間。HP 999・初期シールド30 で討伐不能。
+  // 30 ターン経過で「耐久勝利」扱いとなり、報酬「チョコ片」（cardChocoFragment）獲得。
+  'boss-yoshiko-choco': {
+    id: 'boss-yoshiko-choco',
+    name: 'ヨシュカ・チョコ（討伐不能）',
+    hp: 999, phy: 14, int: 12, agi: 8, imgId: 425,
+    initialShield: 30,
+    enduranceTurns: 30, // main.js が turn 数をチェックして勝利扱いに
+    intentRota: [
+      { kind: 'guard', value: 8 },
+      { kind: 'attack', phyPct: 80 },
+      { kind: 'attackBleed', phyPct: 70, bleedStacks: 1 },
+      { kind: 'guard', value: 6 },
+      { kind: 'attackInt', intPct: 75 },
+    ],
+  },
+
   'boss-troy': {
     id: 'boss-troy',
     name: 'ディープ・ヨシュカ',

--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -1197,6 +1197,125 @@ function makeCardLibrary(clog, api) {
     },
 
     // ════════════════════════════════════════
+    // ヒーローカード（C-1 JIN 編成のパーツ）
+    // 各カードは単体でも使える攻撃/補助。デッキに 3 種揃うと「陣」が発動する。
+    // ════════════════════════════════════════
+    cardZhang: {
+      libraryKey: "cardZhang",
+      extId: 1003,
+      extNameJa: "張遼",
+      skillNameJa: "遼来遼来",
+      skillIcon: "phy.png",
+      cost: 1, type: "atk", target: "enemy.foremost",
+      effectSummaryLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 100, 110);
+        return [`敵にダメージ　${d}`];
+      },
+      peekHelpKeys() { return []; },
+      previewLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 100, 110);
+        return [`敵1体に ${d} ダメージ（PHY 100〜110%）`];
+      },
+      play(s) { api.dealPhySkillToEnemy(s, 100, 110); },
+    },
+    cardLubu: {
+      libraryKey: "cardLubu",
+      extId: 1029, // 赤兎馬の imgId 流用
+      extNameJa: "呂布",
+      skillNameJa: "天下無双",
+      skillIcon: "phy.png",
+      cost: 2, type: "atk", target: "enemy.foremost",
+      effectSummaryLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 180, 200);
+        return [`敵にダメージ　${d}`];
+      },
+      peekHelpKeys() { return []; },
+      previewLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 180, 200);
+        return [`敵1体に ${d} ダメージ（PHY 180〜200%）`];
+      },
+      play(s) { api.dealPhySkillToEnemy(s, 180, 200); },
+    },
+    cardZhaoyun: {
+      libraryKey: "cardZhaoyun",
+      extId: 1058,
+      extNameJa: "趙雲",
+      skillNameJa: "一身是胆",
+      skillIcon: "phy.png",
+      cost: 1, type: "atk", target: "enemy.foremost",
+      effectSummaryLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 80, 90);
+        return [`敵にダメージ　${d}`, "ドロー +1"];
+      },
+      peekHelpKeys() { return ["draw"]; },
+      previewLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 80, 90);
+        return [`敵1体に ${d} ダメージ（PHY 80〜90%）＋カードを 1 枚ドロー`];
+      },
+      play(s) {
+        api.dealPhySkillToEnemy(s, 80, 90);
+        api.drawCards(s, 1);
+      },
+    },
+    cardNapoleon: {
+      libraryKey: "cardNapoleon",
+      extId: 1063,
+      extNameJa: "ナポレオン",
+      skillNameJa: "グランダルメ",
+      skillIcon: "int.png",
+      cost: 2, type: "atk", target: "enemy.all",
+      effectSummaryLines(s) {
+        const d = estIntHit(s.playerInt, s.enemyInt, 90, 100);
+        return [`敵全体に　${d}`];
+      },
+      peekHelpKeys() { return []; },
+      previewLines(s) {
+        const d = estIntHit(s.playerInt, s.enemyInt, 90, 100);
+        return [`敵全体に ${d} ダメージ（INT 90〜100%）`];
+      },
+      play(s) { api.dealIntSkillToEnemy(s, 90, 100); },
+    },
+    cardLincoln: {
+      libraryKey: "cardLincoln",
+      extId: 1064,
+      extNameJa: "リンカーン",
+      skillNameJa: "解放宣言",
+      skillIcon: "BUF_int.png",
+      cost: 1, type: "skl", target: "self",
+      effectSummaryLines() { return ["ガード +8", "INT +2"]; },
+      peekHelpKeys() { return ["guard", "int"]; },
+      previewLines() { return ["ガードを 8 得る・INT を +2"]; },
+      play(s) {
+        se("buff"); fx("player", "buff");
+        s.playerGuard += 8;
+        s.playerInt += 2;
+        clog("解放宣言: ガード+8、INT+2");
+      },
+    },
+    cardRobinhood: {
+      libraryKey: "cardRobinhood",
+      extId: 1083,
+      extNameJa: "ロビンフッド",
+      skillNameJa: "シャーウッドの矢",
+      skillIcon: "phy.png",
+      cost: 1, type: "atk", target: "enemy.foremost",
+      effectSummaryLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 80, 90);
+        return [`敵にダメージ　${d}`, "出血 ×2 付与"];
+      },
+      peekHelpKeys() { return ["bleed"]; },
+      previewLines(s) {
+        const d = estPhyHit(s.playerPhy, s.enemyPhy, 80, 90);
+        return [`敵1体に ${d} ダメージ＋出血 ×2 付与`];
+      },
+      play(s) {
+        api.dealPhySkillToEnemy(s, 80, 90);
+        s.enemyBleed = (s.enemyBleed || 0) + 2;
+        clog("出血 ×2 付与（敵）");
+      },
+    },
+
+    // ════════════════════════════════════════
     // 特殊：「ヨシュカ・チョコ」耐久報酬
     // 30ターン耐え切ったプレイヤーに渡される伝説の Power 系カード。
     // 元タイトル 2019 年 2nd レイドで時間切れになった証。
@@ -1333,7 +1452,52 @@ export const CARD_RARITIES = {
   cardShingenPre:  'legendary', // 武田信玄（暫定版・1戦闘後にナーフ）
   cardShingenPost: 'rare',      // 武田信玄（ナーフ後）
   cardChocoFragment: 'legendary', // チョコ片（ヨシュカ・チョコ耐久報酬）
+
+  // ─── ヒーローカード（C-1 JIN 編成のパーツ） ───────────────────
+  cardZhang:      'rare',
+  cardLubu:       'epic',
+  cardZhaoyun:    'rare',
+  cardNapoleon:   'epic',
+  cardLincoln:    'rare',
+  cardRobinhood:  'rare',
 };
+
+/**
+ * JIN（陣）定義 — 元タイトル 2019 年 JINβ のリスペクト。
+ * デッキに該当ヒーローカード3枚が揃うと発動。
+ *  applyAtCombatStart(combat, runState): 戦闘開始時に1度だけ呼ばれる
+ *  applyDiscount(card, combat) → number  : カードプレイ時のコスト割引
+ */
+export const JIN_DEFS = [
+  {
+    id: 'sangokushi',
+    name: '三国志陣',
+    members: ['cardZhang', 'cardLubu', 'cardZhaoyun'],
+    desc: 'PHY 攻撃カードのコスト -1（最低 0）',
+    color: '#d63031',
+    applyDiscount(card) {
+      // type=atk かつ skillIcon が phy.png のものを 1 ディスカウント
+      if (card.type === 'atk' && (card.skillIcon || '').toLowerCase().includes('phy')) return 1;
+      return 0;
+    },
+  },
+  {
+    id: 'revolution',
+    name: '西洋革命陣',
+    members: ['cardNapoleon', 'cardLincoln', 'cardRobinhood'],
+    desc: 'HP1 で行動時、致死ダメで 1 度だけ生存（リザレクション）',
+    color: '#0984e3',
+    applyAtCombatStart(combat) {
+      combat.hasResurrection = true;
+    },
+  },
+];
+
+/** デッキから発動中の JIN を抽出（重複ID無視） */
+export function detectActiveJins(deck) {
+  const ids = new Set(deck.map(c => c.libraryKey));
+  return JIN_DEFS.filter(j => j.members.every(m => ids.has(m)));
+}
 
 /**
  * カードランクアップ系列（ノービス → エリート）

--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -1132,6 +1132,69 @@ function makeCardLibrary(clog, api) {
       previewLines() { return ["このターン（ターン終了まで）受けるダメージをすべて半減する"]; },
       play(s) { api.setDamageReducedThisTurn(s); },
     },
+
+    // ════════════════════════════════════════
+    // 特殊：「武田信玄調整事件」イベント専用カード
+    // 元タイトル初のナーフ事案の再現。pre は HP25%固定の超強力 PHY バフ、
+    // 1戦闘後にゲーム側ロジックで post（10〜25%ランダム）に強制置換される。
+    // ════════════════════════════════════════
+    cardShingenPre: {
+      libraryKey: "cardShingenPre",
+      extId: 1019, // 武田信玄のヒーローID（imgId 流用）
+      extNameJa: "武田信玄（暫定版）",
+      skillNameJa: "風林火山",
+      skillIcon: "BUF_phy.png",
+      cost: 2,
+      type: "skl",
+      target: "self",
+      pendingNerf: true, // 戦闘終了時にナーフされる目印
+      effectSummaryLines(s) {
+        const bonus = Math.floor((s.playerHpMax || 70) * 0.25);
+        return [`PHY +${bonus}（最大HPの25%固定）`];
+      },
+      peekHelpKeys() { return ["phy"]; },
+      previewLines(s) {
+        const bonus = Math.floor((s.playerHpMax || 70) * 0.25);
+        return [
+          `PHY を +${bonus}（最大HPの25%固定・戦闘中ずっと）`,
+          "⚠ 戦闘終了後、ナーフ後バージョンに置換されます",
+        ];
+      },
+      play(s) {
+        se("buff"); fx("player", "buff");
+        const bonus = Math.floor((s.playerHpMax || 70) * 0.25);
+        s.playerPhy += bonus;
+        clog(`風林火山: PHY +${bonus}（暫定版・固定値）`);
+      },
+    },
+    cardShingenPost: {
+      libraryKey: "cardShingenPost",
+      extId: 1019,
+      extNameJa: "武田信玄（ナーフ後）",
+      skillNameJa: "風林火山",
+      skillIcon: "BUF_phy.png",
+      cost: 2,
+      type: "skl",
+      target: "self",
+      effectSummaryLines(s) {
+        const lo = Math.floor((s.playerHpMax || 70) * 0.10);
+        const hi = Math.floor((s.playerHpMax || 70) * 0.25);
+        return [`PHY +${lo}〜${hi}（ランダム）`];
+      },
+      peekHelpKeys() { return ["phy"]; },
+      previewLines(s) {
+        const lo = Math.floor((s.playerHpMax || 70) * 0.10);
+        const hi = Math.floor((s.playerHpMax || 70) * 0.25);
+        return [`PHY を +${lo}〜${hi}（最大HPの10〜25%・ランダム・戦闘中ずっと）`];
+      },
+      play(s) {
+        se("buff"); fx("player", "buff");
+        const pct = 0.10 + Math.random() * 0.15;
+        const bonus = Math.floor((s.playerHpMax || 70) * pct);
+        s.playerPhy += bonus;
+        clog(`風林火山: PHY +${bonus}（ナーフ後・ランダム）`);
+      },
+    },
   };
 }
 
@@ -1231,6 +1294,10 @@ export const CARD_RARITIES = {
   cd204:   'rare',      // エリートプロテクション（ガード+12）
   cd205:   'rare',      // エリートショット（INT×3）
   cd206:   'uncommon',  // 投資（GUM+20）
+
+  // ─── 特殊：イベント専用カード ────────────────────────────────────
+  cardShingenPre:  'legendary', // 武田信玄（暫定版・1戦闘後にナーフ）
+  cardShingenPost: 'rare',      // 武田信玄（ナーフ後）
 };
 
 /**

--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -1195,6 +1195,40 @@ function makeCardLibrary(clog, api) {
         clog(`風林火山: PHY +${bonus}（ナーフ後・ランダム）`);
       },
     },
+
+    // ════════════════════════════════════════
+    // 特殊：「ヨシュカ・チョコ」耐久報酬
+    // 30ターン耐え切ったプレイヤーに渡される伝説の Power 系カード。
+    // 元タイトル 2019 年 2nd レイドで時間切れになった証。
+    // ════════════════════════════════════════
+    cardChocoFragment: {
+      libraryKey: "cardChocoFragment",
+      extId: 380, // チョコ系（カスケード フラペチーノ近似）の imgId
+      extNameJa: "チョコ片",
+      skillNameJa: "甘美なる耐久",
+      skillIcon: "BUF_phy.png",
+      cost: 0,
+      type: "skl",
+      target: "self",
+      effectSummaryLines() {
+        return ["シールド +20", "PHY +5", "INT +5（戦闘中ずっと）"];
+      },
+      peekHelpKeys() { return ["shield", "phy", "int"]; },
+      previewLines() {
+        return [
+          "シールドを 20 得る（特殊ダメージ吸収）",
+          "PHY を +5・INT を +5（戦闘中ずっと）",
+          "コスト 0 の超強力カード（耐久勝利の証）",
+        ];
+      },
+      play(s) {
+        se("buff"); fx("player", "buff");
+        s.playerShield = (s.playerShield || 0) + 20;
+        s.playerPhy += 5;
+        s.playerInt += 5;
+        clog("甘美なる耐久: シールド+20・PHY+5・INT+5");
+      },
+    },
   };
 }
 
@@ -1298,6 +1332,7 @@ export const CARD_RARITIES = {
   // ─── 特殊：イベント専用カード ────────────────────────────────────
   cardShingenPre:  'legendary', // 武田信玄（暫定版・1戦闘後にナーフ）
   cardShingenPost: 'rare',      // 武田信玄（ナーフ後）
+  cardChocoFragment: 'legendary', // チョコ片（ヨシュカ・チョコ耐久報酬）
 };
 
 /**

--- a/prototype/js/chapters.js
+++ b/prototype/js/chapters.js
@@ -2,6 +2,9 @@
  * 章定義（SPEC-004 §6〜§8）
  * cardPool: cards.js の CARD_LIBRARY のキー。報酬とショップで使用。
  * 章 N の報酬プールは章 1〜N の cardPool を累積する（main.js 側で処理）。
+ *
+ * extSeries: 表示専用フレーバー。元タイトル「ノードVer.x」更新の歴史を踏襲し、
+ *   各章で「あの頃のドロップ」を体感する仕掛け（main.js 側でマップヘッダーに表示）。
  */
 export const CHAPTERS = [
   // ─── 章 0 ─────────────────────────────────────────────────────────
@@ -20,6 +23,11 @@ export const CHAPTERS = [
     cardPool: ['cd101', 'cd102', 'cd103', 'cd104', 'cd105', 'cd106', 'cd107', 'cd108', 'ext2004'],
     bossId: 'boss-ch1',
     bossRewardGold: 50,
+    extSeries: {
+      nodeVer: 'Ver 1.1',
+      era: 'Eco 1.0 (Lab/GUM)',
+      items: ['カタナ', 'ブック', 'リング', 'シールド'],
+    },
   },
   // ─── 章 1 ─────────────────────────────────────────────────────────
   {
@@ -37,6 +45,11 @@ export const CHAPTERS = [
     cardPool: ['cdH01', 'cdH02', 'cdH03', 'cdH04', 'cdH05', 'cdH06'],
     bossId: 'boss-hl',
     bossRewardGold: 70,
+    extSeries: {
+      nodeVer: 'Ver 1.2',
+      era: 'ランド時代',
+      items: ['ハルバード', 'スクロール', 'ネックレス', 'カブト'],
+    },
   },
   // ─── 章 2 ─────────────────────────────────────────────────────────
   {
@@ -54,6 +67,11 @@ export const CHAPTERS = [
     cardPool: ['cd301', 'cd302', 'cd303', 'cd304', 'cd305'],
     bossId: 'boss-ch3',
     bossRewardGold: 100,
+    extSeries: {
+      nodeVer: 'Ver 1.5',
+      era: 'JIN試験時代',
+      items: ['ナイフ', 'リソグラフィ', 'アルケブス', 'ウィップ'],
+    },
   },
   // ─── 章 3 ─────────────────────────────────────────────────────────
   {
@@ -71,6 +89,11 @@ export const CHAPTERS = [
     cardPool: ['cd201', 'cd202', 'cd203', 'cd204', 'cd205', 'cd206'],
     bossId: 'boss-ch2',
     bossRewardGold: 120,
+    extSeries: {
+      nodeVer: 'Ver 1.6',
+      era: 'Eco 3.0 / MCHC時代',
+      items: ['シックル', 'ワンド', 'サケ', 'ハット'],
+    },
   },
   // ─── 章 4 ─────────────────────────────────────────────────────────
   {
@@ -93,5 +116,10 @@ export const CHAPTERS = [
     ],
     bossId: 'boss-troy',
     bossRewardGold: 180,
+    extSeries: {
+      nodeVer: 'Ver 1.8',
+      era: 'MCH Verse時代',
+      items: ['スタッフ', 'ホーキ', 'ヨロイ'],
+    },
   },
 ];

--- a/prototype/js/chapters.js
+++ b/prototype/js/chapters.js
@@ -20,7 +20,9 @@ export const CHAPTERS = [
     },
     enemyPool: ['sn-001', 'sn-002', 'sn-003'],
     elitePool: ['sn-e01'],
-    cardPool: ['cd101', 'cd102', 'cd103', 'cd104', 'cd105', 'cd106', 'cd107', 'cd108', 'ext2004'],
+    cardPool: ['cd101', 'cd102', 'cd103', 'cd104', 'cd105', 'cd106', 'cd107', 'cd108', 'ext2004',
+      // 三国志陣のパーツ（C-1 JIN）
+      'cardZhang', 'cardLubu', 'cardZhaoyun'],
     bossId: 'boss-ch1',
     bossRewardGold: 50,
     extSeries: {
@@ -42,7 +44,9 @@ export const CHAPTERS = [
     },
     enemyPool: ['hl-001', 'hl-002', 'hl-003'],
     elitePool: ['hl-e01'],
-    cardPool: ['cdH01', 'cdH02', 'cdH03', 'cdH04', 'cdH05', 'cdH06'],
+    cardPool: ['cdH01', 'cdH02', 'cdH03', 'cdH04', 'cdH05', 'cdH06',
+      // 西洋革命陣のパーツ（C-1 JIN）
+      'cardNapoleon', 'cardLincoln', 'cardRobinhood'],
     bossId: 'boss-hl',
     bossRewardGold: 70,
     extSeries: {

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -957,9 +957,16 @@ function renderMap() {
   const titleEl = document.getElementById("mapTitle");
   if (titleEl) {
     const chapter = CHAPTERS[runState.chapterIdx];
-    titleEl.textContent = runState.runComplete
-      ? `全ランクリア！（${CHAPTERS.length} 章突破・トロイ制覇）`
-      : `章 ${chapter.id}「${chapter.name}」（下から上へ進む）`;
+    if (runState.runComplete) {
+      titleEl.textContent = `全ランクリア！（${CHAPTERS.length} 章突破・トロイ制覇）`;
+    } else {
+      const series = chapter.extSeries;
+      const seriesLine = series
+        ? `\n📦 ${series.nodeVer}・${series.era}：${series.items.join(' / ')}`
+        : '';
+      titleEl.textContent = `章 ${chapter.id}「${chapter.name}」（下から上へ進む）${seriesLine}`;
+      titleEl.style.whiteSpace = 'pre-line';
+    }
   }
 
   if (runState.runComplete) {

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -1346,7 +1346,9 @@ function startCombatFromMapNode(node) {
 
   if (node.type === "boss") {
     isBoss = true;
-    bossDef = BOSS_DEFS[chapter.bossId];
+    // node.bossOverrideId が指定されていれば章間レイド扱い（B-4）
+    const bId = node.bossOverrideId || chapter.bossId;
+    bossDef = BOSS_DEFS[bId];
     enemyDef = bossDef;
   } else if (node.enemyDefId && ENEMY_DEFS[node.enemyDefId]) {
     enemyDef = ENEMY_DEFS[node.enemyDefId];
@@ -2136,6 +2138,13 @@ async function enemyTurn() {
   if (combat.enemyHp <= 0) { endCombatWin(); return; }
 
   combat.turn++;
+  // 耐久勝利チェック（B-4 ヨシュカ・チョコ）：endurance ターン経過で勝利扱い
+  if (combat.bossDef?.enduranceTurns && combat.turn > combat.bossDef.enduranceTurns) {
+    combat.enduranceWin = true;
+    clog(`⏰ 耐久勝利！${combat.bossDef.enduranceTurns}ターン凌ぎ切った…`);
+    endCombatWin();
+    return;
+  }
   startPlayerTurn();
 }
 
@@ -2174,6 +2183,39 @@ function endCombatWin() {
   const chapter = CHAPTERS[runState.chapterIdx];
   const isBoss = combat.isBoss;
   const isElite = combat.isElite;
+
+  // ── 章間レイド勝利の特別処理（B-4） ──
+  // 通常報酬画面を経由せず、固有カードを直接付与して次章マップへ戻る
+  const interludeBossId = combat.bossDef?.id;
+  if (interludeBossId === 'boss-yoshiko' || interludeBossId === 'boss-yoshiko-choco') {
+    const isChoco = interludeBossId === 'boss-yoshiko-choco';
+    const wasEndurance = combat.enduranceWin === true;
+    runState.playerHp = combat.playerHp;
+    runState.playerHpMax = combat.playerHpMax;
+    runState.deck = combat.deck.map(c => ({ ...c }));
+    if (isChoco && wasEndurance) {
+      runState.deck.push(copyCard("cardChocoFragment"));
+      clog("🍫 「チョコ片」を入手！（耐久勝利の証）");
+      renderNavigator("ヨシュカ・チョコの30ターン耐久に成功しました！「チョコ片」をデッキに追加しました。");
+    } else if (isChoco) {
+      // 通常撃破は基本起こらないが、念のため
+      runState.deck.push(copyCard("cardChocoFragment"));
+      clog("🍫 まさかの撃破！「チョコ片」を入手");
+    } else {
+      // ヨシュカ通常撃破：報酬は微妙な GUM のみ
+      gold += 12;
+      clog("🍵 ヨシュカ撃破：GUM +12（…報酬は微妙）");
+      renderNavigator("ヨシュカは弱すぎて1日で討伐されました。報酬は微妙でしたね…");
+    }
+    runState.activeInterlude = null;
+    combat = null;
+    postCombatSnapshot = null;
+    stopBgm();
+    showView("map");
+    renderMap();
+    syncResources();
+    return;
+  }
 
   // GUM
   let earnedGold = isBoss ? chapter.bossRewardGold : isElite ? 45 : 28;
@@ -2327,6 +2369,18 @@ function advanceAfterRewardPick(libraryKey) {
         document.getElementById("gameOverMsg").textContent =
           "全 node クリアおめでとうございます！あなたは最高ですよ〜！";
       } else {
+        // 章間レイドの判定（B-4）
+        // clearedIdx 0 → ヨシュカ（簡単）／ clearedIdx 1 → ヨシュカ・チョコ（耐久）
+        if (clearedIdx === 0 && !runState.yoshikoCleared) {
+          runState.yoshikoCleared = true;
+          startInterludeCombat('boss-yoshiko', '🍵 章間レイド：ヨシュカ');
+          return;
+        }
+        if (clearedIdx === 1 && !runState.yoshikoChocoCleared) {
+          runState.yoshikoChocoCleared = true;
+          startInterludeCombat('boss-yoshiko-choco', '🍫 章間レイド：ヨシュカ・チョコ（30ターン耐久）');
+          return;
+        }
         // 次章のマップへそのまま遷移（runState.deck / playerHp / llExtSlots を引き継ぎ） #31
         // advanceToNextChapter() で chapterIdx++ と新章マップのセットアップは既に完了
         showView("map");
@@ -3467,6 +3521,32 @@ function leaveScout() {
   syncResources();
   showView("map");
   renderMap();
+}
+
+// ─── 章間レイド（B-4 ヨシュカ／ヨシュカ・チョコ） ─────────────────
+/**
+ * 章間に出現する特殊レイド戦闘を開始する。
+ * 通常の boss ノードを通さず、bossDef を直接渡してバトルに突入。
+ */
+function startInterludeCombat(bossId, narration) {
+  ensureRunState();
+  runState.activeInterlude = bossId;
+  const bossDef = BOSS_DEFS[bossId];
+  if (!bossDef) {
+    console.warn('未定義の interlude boss:', bossId);
+    showView("map"); renderMap();
+    return;
+  }
+  // 章 bossId をいじらず、bossOverrideId で直接指定
+  const fakeNode = {
+    id: `INTERLUDE-${bossId}`,
+    type: "boss",
+    elite: false,
+    enemyImgId: bossDef.imgId,
+    bossOverrideId: bossId,
+  };
+  clog(narration);
+  startCombatFromMapNode(fakeNode);
 }
 
 /**

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -850,6 +850,8 @@ function ensureRunState() {
       pathNodeIds: [],
       runComplete: false,
       llExtSlots: [null, null],
+      cp: 0,         // デッキ素材（休憩・クラフトで貯まる、打ち直しに使用）
+      mchc: 0,       // 上位通貨（エリート/ボスでドロップ、ボス前ショップで Legendary 解放）
     };
   }
 }
@@ -917,6 +919,11 @@ function syncResources() {
   }
   const chapterEl = document.getElementById("chapterVal");
   if (chapterEl) chapterEl.textContent = String((runState.chapterIdx ?? 0) + 1);
+  // Cp / MCHC 表示
+  const cpEl = document.getElementById("cpVal");
+  if (cpEl) cpEl.textContent = String(runState.cp ?? 0);
+  const mchcEl = document.getElementById("mchcVal");
+  if (mchcEl) mchcEl.textContent = String(runState.mchc ?? 0);
   syncLlExtSlots();
   const layerEl = document.getElementById("layerVal");
   if (layerEl) {
@@ -1168,18 +1175,20 @@ function tryEnterMapNode(nodeId) {
     const heal = Math.floor(runState.playerHpMax * 0.35);
     const actualHeal = Math.min(runState.playerHpMax, runState.playerHp + heal) - runState.playerHp;
     runState.playerHp = Math.min(runState.playerHpMax, runState.playerHp + heal);
+    runState.cp = (runState.cp ?? 0) + 1;  // 休憩で Cp+1
     runState.pathNodeIds.push(nodeId);
     runState.lastMapNodeId = nodeId;
-    clog(`休憩で HP+${actualHeal}`);
+    clog(`休憩で HP+${actualHeal}・Cp+1`);
     playBattleSe("heal");
     renderMap();
+    syncResources();
     // マイのナレーション（renderMap 内の renderNavigator より後に上書き）
     const hpAfter = runState.playerHp;
     const hpMax = runState.playerHpMax;
     renderNavigator(
       actualHeal > 0
-        ? `休憩できましたね！HP が ${hpAfter}/${hpMax} に回復しました。さあ、次へ進みましょう！`
-        : `すでに満タンです！${hpAfter}/${hpMax}。この調子でボスを倒しましょう！`
+        ? `休憩できましたね！HP が ${hpAfter}/${hpMax} に回復し、Cp も 1 貯まりました。さあ、次へ進みましょう！`
+        : `すでに満タンです！${hpAfter}/${hpMax}。Cp を 1 入手しました。この調子でボスを倒しましょう！`
     );
     return;
   }
@@ -1193,7 +1202,80 @@ function tryEnterMapNode(nodeId) {
     openCraftScreen();
     return;
   }
+  // ボス突入前の MCHC ショップ：MCHC を持っていれば LL ext と交換できる
+  if (node.type === "boss" && (runState.mchc ?? 0) >= 1 && runState.llExtSlots.some(s => s === null)) {
+    openMchcShopModal(() => startCombatFromMapNode(node));
+    return;
+  }
   startCombatFromMapNode(node);
+}
+
+// ─── MCHC ショップ（ボス前 Legendary 解放） ────────────────────────
+function openMchcShopModal(onClose) {
+  ensureRunState();
+  const overlay = document.createElement("div");
+  overlay.style.cssText =
+    "position:fixed;inset:0;background:rgba(0,0,0,0.85);display:flex;align-items:center;justify-content:center;z-index:9999;padding:1rem";
+  const card = document.createElement("div");
+  card.style.cssText =
+    "background:var(--bg);border:1px solid var(--accent);border-radius:8px;padding:1.5rem;max-width:520px;width:100%;max-height:90vh;overflow-y:auto";
+
+  const renderShop = () => {
+    const remainingMchc = runState.mchc ?? 0;
+    const emptySlot = runState.llExtSlots.findIndex(s => s === null);
+    const offers = shuffle(LL_EXT_POOL.slice()).slice(0, 3);
+
+    card.innerHTML = `
+      <h2 style="margin:0 0 0.5rem;color:var(--accent)">💠 MCHC ショップ</h2>
+      <p style="margin:0 0 1rem;font-size:0.85rem;color:var(--muted)">
+        ボス前限定。MCHC を消費して Legendary 枠を解放できます。<br>
+        所持: 💠 <strong>${remainingMchc}</strong> MCHC・空きスロット: <strong>${runState.llExtSlots.filter(s => s === null).length}</strong>
+      </p>
+    `;
+    if (emptySlot < 0) {
+      card.innerHTML += `<p style="color:var(--muted)">LLスロットに空きがありません。</p>`;
+    } else if (remainingMchc < 1) {
+      card.innerHTML += `<p style="color:var(--muted)">MCHC が足りません。</p>`;
+    } else {
+      const list = document.createElement("div");
+      list.style.cssText = "display:flex;flex-direction:column;gap:0.5rem;margin:0.5rem 0";
+      offers.forEach(ll => {
+        const row = document.createElement("button");
+        row.type = "button";
+        row.className = "action";
+        row.style.cssText =
+          "text-align:left;padding:0.5rem 0.75rem;background:var(--card-bg);border:1px solid var(--border);border-radius:6px;cursor:pointer";
+        row.innerHTML = `
+          <div style="font-weight:700;color:var(--accent)">✨ ${ll.name}（💠 1 MCHC）</div>
+          <div style="font-size:0.8rem;color:var(--muted)">${ll.skillName} ／ ${ll.desc}</div>
+        `;
+        row.addEventListener("click", () => {
+          runState.mchc -= 1;
+          const slot = runState.llExtSlots.findIndex(s => s === null);
+          if (slot >= 0) runState.llExtSlots[slot] = ll;
+          clog(`💠 MCHC -1：「${ll.name}」を Legendary 枠に獲得`);
+          syncResources();
+          renderShop();
+        });
+        list.appendChild(row);
+      });
+      card.appendChild(list);
+    }
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "action primary";
+    close.style.cssText = "width:100%;margin-top:0.75rem";
+    close.textContent = "ボスへ進む →";
+    close.addEventListener("click", () => {
+      overlay.remove();
+      onClose && onClose();
+    });
+    card.appendChild(close);
+  };
+
+  renderShop();
+  overlay.appendChild(card);
+  document.body.appendChild(overlay);
 }
 
 // ─── ビュー切り替え ───────────────────────────────────────────────
@@ -2048,10 +2130,18 @@ function endCombatWin() {
   const isBoss = combat.isBoss;
   const isElite = combat.isElite;
 
-  // ゴールド
+  // GUM
   const earnedGold = isBoss ? chapter.bossRewardGold : isElite ? 45 : 28;
   gold += earnedGold;
-  clog(`勝利！ GUM +${earnedGold}`);
+
+  // MCHC：エリート +1 / ボス +2（高難度ノード突破でドロップ）
+  const earnedMchc = isBoss ? 2 : isElite ? 1 : 0;
+  if (earnedMchc > 0) {
+    runState.mchc = (runState.mchc ?? 0) + earnedMchc;
+    clog(`勝利！ GUM +${earnedGold}・💠 MCHC +${earnedMchc}`);
+  } else {
+    clog(`勝利！ GUM +${earnedGold}`);
+  }
 
   // 報酬カードプール（累積）
   const pool = shuffle(getCumulativeCardPool());
@@ -3063,10 +3153,28 @@ function renderHeroSelect() {
 }
 
 // ─── クラフト画面 ────────────────────────────────────────────────────
+const CRAFT_UPGRADE_CP_COST = 1;
+
 function openCraftScreen() {
   showView("craft");
   const el = document.getElementById("craftView");
   if (!el) return;
+  ensureRunState();
+  // クラフト訪問で Cp+1（同じノード再入場では加算しない）
+  if (!runState.craftCpAwarded) {
+    runState.craftCpAwarded = new Set();
+  }
+  if (pendingCraftNodeId && !runState.craftCpAwarded.has(pendingCraftNodeId)) {
+    runState.cp = (runState.cp ?? 0) + 1;
+    runState.craftCpAwarded.add(pendingCraftNodeId);
+  }
+  syncResources();
+
+  const cp = runState.cp ?? 0;
+  const upgradeDisabled = cp < CRAFT_UPGRADE_CP_COST;
+  const upgradeBadge = upgradeDisabled
+    ? `<span style="color:var(--muted);font-size:0.85em">（Cp ${CRAFT_UPGRADE_CP_COST} 必要・所持 ${cp}）</span>`
+    : `<span style="color:var(--accent);font-size:0.85em">（Cp ${CRAFT_UPGRADE_CP_COST} 消費・所持 ${cp}）</span>`;
 
   el.innerHTML = `
     <div class="craft-header">
@@ -3080,9 +3188,9 @@ function openCraftScreen() {
         <button class="action craft-opt-btn" id="btnCraftGet">獲得する</button>
       </div>
       <div class="craft-option" id="craftOptUpgrade">
-        <div class="craft-opt-title">打ち直し</div>
+        <div class="craft-opt-title">打ち直し ${upgradeBadge}</div>
         <div class="craft-opt-desc">デッキ内のノービスカードを1枚選んでエリートにランクアップします。</div>
-        <button class="action craft-opt-btn" id="btnCraftUpgrade">打ち直す</button>
+        <button class="action craft-opt-btn" id="btnCraftUpgrade" ${upgradeDisabled ? "disabled" : ""}>打ち直す</button>
       </div>
     </div>
     <button class="craft-leave-btn" id="btnLeaveCraft">← マップに戻る</button>
@@ -3091,9 +3199,12 @@ function openCraftScreen() {
   document.getElementById("btnCraftGet").addEventListener("click", () => {
     openCraftGetCard();
   });
-  document.getElementById("btnCraftUpgrade").addEventListener("click", () => {
-    openCraftUpgrade();
-  });
+  const upBtn = document.getElementById("btnCraftUpgrade");
+  if (!upgradeDisabled) {
+    upBtn.addEventListener("click", () => {
+      openCraftUpgrade();
+    });
+  }
   document.getElementById("btnLeaveCraft").addEventListener("click", () => {
     leaveCraft();
   });
@@ -3196,10 +3307,15 @@ function openCraftUpgrade() {
 
     const selBtn = document.createElement("button");
     selBtn.className = "action craft-opt-btn";
-    selBtn.textContent = "このカードを強化";
+    selBtn.textContent = `このカードを強化（Cp ${CRAFT_UPGRADE_CP_COST}）`;
     selBtn.addEventListener("click", () => {
+      if ((runState.cp ?? 0) < CRAFT_UPGRADE_CP_COST) {
+        clog("Cp が足りません");
+        return;
+      }
+      runState.cp -= CRAFT_UPGRADE_CP_COST;
       runState.deck[idx] = copyCard(upgradeKey);
-      clog(`打ち直し: ${card.extNameJa} → ${upgradeDef.extNameJa}`);
+      clog(`打ち直し: ${card.extNameJa} → ${upgradeDef.extNameJa}（Cp -${CRAFT_UPGRADE_CP_COST}）`);
       leaveCraft();
     });
 

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -859,6 +859,7 @@ function ensureRunState() {
       llExtSlots: [null, null],
       cp: 0,         // デッキ素材（休憩・クラフトで貯まる、打ち直しに使用）
       mchc: 0,       // 上位通貨（エリート/ボスでドロップ、ボス前ショップで Legendary 解放）
+      magicStones: 0, // 輝く原石（ext を 2 枚 burn で 1 個。LL 交換に使用）
     };
   }
 }
@@ -931,6 +932,8 @@ function syncResources() {
   if (cpEl) cpEl.textContent = String(runState.cp ?? 0);
   const mchcEl = document.getElementById("mchcVal");
   if (mchcEl) mchcEl.textContent = String(runState.mchc ?? 0);
+  const stoneEl = document.getElementById("stoneVal");
+  if (stoneEl) stoneEl.textContent = String(runState.magicStones ?? 0);
   // スカウトランド表示（選択済みなら名前を chapter 表示の脇に追加）
   const chapterEl2 = document.getElementById("chapterVal");
   if (chapterEl2) {
@@ -1236,8 +1239,10 @@ function tryEnterMapNode(nodeId) {
     openScoutScreen();
     return;
   }
-  // ボス突入前の MCHC ショップ：MCHC を持っていれば LL ext と交換できる
-  if (node.type === "boss" && (runState.mchc ?? 0) >= 1 && runState.llExtSlots.some(s => s === null)) {
+  // ボス突入前の MCHC / 原石ショップ：LL ext と交換できる（空きスロットがあるとき）
+  const canMchc = (runState.mchc ?? 0) >= 1;
+  const canStones = (runState.magicStones ?? 0) >= 2;
+  if (node.type === "boss" && (canMchc || canStones) && runState.llExtSlots.some(s => s === null)) {
     openMchcShopModal(() => startCombatFromMapNode(node));
     return;
   }
@@ -1256,42 +1261,68 @@ function openMchcShopModal(onClose) {
 
   const renderShop = () => {
     const remainingMchc = runState.mchc ?? 0;
+    const remainingStones = runState.magicStones ?? 0;
     const emptySlot = runState.llExtSlots.findIndex(s => s === null);
     const offers = shuffle(LL_EXT_POOL.slice()).slice(0, 3);
 
     card.innerHTML = `
       <h2 style="margin:0 0 0.5rem;color:var(--accent)">💠 MCHC ショップ</h2>
       <p style="margin:0 0 1rem;font-size:0.85rem;color:var(--muted)">
-        ボス前限定。MCHC を消費して Legendary 枠を解放できます。<br>
-        所持: 💠 <strong>${remainingMchc}</strong> MCHC・空きスロット: <strong>${runState.llExtSlots.filter(s => s === null).length}</strong>
+        ボス前限定。MCHC または 💎輝く原石 を消費して Legendary 枠を解放できます。<br>
+        所持: 💠 <strong>${remainingMchc}</strong> MCHC・💎 <strong>${remainingStones}</strong> 原石・空きスロット: <strong>${runState.llExtSlots.filter(s => s === null).length}</strong>
       </p>
     `;
     if (emptySlot < 0) {
       card.innerHTML += `<p style="color:var(--muted)">LLスロットに空きがありません。</p>`;
-    } else if (remainingMchc < 1) {
-      card.innerHTML += `<p style="color:var(--muted)">MCHC が足りません。</p>`;
+    } else if (remainingMchc < 1 && remainingStones < 2) {
+      card.innerHTML += `<p style="color:var(--muted)">MCHC または 💎×2 が必要です。</p>`;
     } else {
       const list = document.createElement("div");
       list.style.cssText = "display:flex;flex-direction:column;gap:0.5rem;margin:0.5rem 0";
       offers.forEach(ll => {
-        const row = document.createElement("button");
-        row.type = "button";
-        row.className = "action";
-        row.style.cssText =
-          "text-align:left;padding:0.5rem 0.75rem;background:var(--card-bg);border:1px solid var(--border);border-radius:6px;cursor:pointer";
-        row.innerHTML = `
-          <div style="font-weight:700;color:var(--accent)">✨ ${ll.name}（💠 1 MCHC）</div>
-          <div style="font-size:0.8rem;color:var(--muted)">${ll.skillName} ／ ${ll.desc}</div>
-        `;
-        row.addEventListener("click", () => {
-          runState.mchc -= 1;
-          const slot = runState.llExtSlots.findIndex(s => s === null);
-          if (slot >= 0) runState.llExtSlots[slot] = ll;
-          clog(`💠 MCHC -1：「${ll.name}」を Legendary 枠に獲得`);
-          syncResources();
-          renderShop();
-        });
-        list.appendChild(row);
+        const canBuyMchc = remainingMchc >= 1;
+        const canBuyStones = remainingStones >= 2;
+
+        if (canBuyMchc) {
+          const row = document.createElement("button");
+          row.type = "button";
+          row.className = "action";
+          row.style.cssText =
+            "text-align:left;padding:0.5rem 0.75rem;background:var(--card-bg);border:1px solid var(--border);border-radius:6px;cursor:pointer";
+          row.innerHTML = `
+            <div style="font-weight:700;color:var(--accent)">✨ ${ll.name}（💠 1 MCHC）</div>
+            <div style="font-size:0.8rem;color:var(--muted)">${ll.skillName} ／ ${ll.desc}</div>
+          `;
+          row.addEventListener("click", () => {
+            runState.mchc -= 1;
+            const slot = runState.llExtSlots.findIndex(s => s === null);
+            if (slot >= 0) runState.llExtSlots[slot] = ll;
+            clog(`💠 MCHC -1：「${ll.name}」を Legendary 枠に獲得`);
+            syncResources();
+            renderShop();
+          });
+          list.appendChild(row);
+        }
+        if (canBuyStones) {
+          const row2 = document.createElement("button");
+          row2.type = "button";
+          row2.className = "action";
+          row2.style.cssText =
+            "text-align:left;padding:0.5rem 0.75rem;background:var(--card-bg);border:1px solid #888;border-radius:6px;cursor:pointer";
+          row2.innerHTML = `
+            <div style="font-weight:700">💎 ${ll.name}（💎 2 原石）</div>
+            <div style="font-size:0.8rem;color:var(--muted)">${ll.skillName} ／ ${ll.desc}</div>
+          `;
+          row2.addEventListener("click", () => {
+            runState.magicStones -= 2;
+            const slot = runState.llExtSlots.findIndex(s => s === null);
+            if (slot >= 0) runState.llExtSlots[slot] = ll;
+            clog(`💎 原石 -2：「${ll.name}」を Legendary 枠に獲得`);
+            syncResources();
+            renderShop();
+          });
+          list.appendChild(row2);
+        }
       });
       card.appendChild(list);
     }
@@ -3333,10 +3364,13 @@ function openCraftScreen() {
     ? `<span style="color:var(--muted);font-size:0.85em">（Cp ${CRAFT_UPGRADE_CP_COST} 必要・所持 ${cp}）</span>`
     : `<span style="color:var(--accent);font-size:0.85em">（Cp ${CRAFT_UPGRADE_CP_COST} 消費・所持 ${cp}）</span>`;
 
+  const burnDisabled = runState.deck.length < 2;
+  const stones = runState.magicStones ?? 0;
+
   el.innerHTML = `
     <div class="craft-header">
       <h2>クラフト</h2>
-      <p class="craft-sub">エクステンションを獲得するか、デッキを強化しましょう</p>
+      <p class="craft-sub">エクステンションを獲得・打ち直し・焼却（EMA3）。所持 💎 ${stones} 個</p>
     </div>
     <div class="craft-choices">
       <div class="craft-option" id="craftOptGet">
@@ -3348,6 +3382,11 @@ function openCraftScreen() {
         <div class="craft-opt-title">打ち直し ${upgradeBadge}</div>
         <div class="craft-opt-desc">デッキ内のノービスカードを1枚選んでエリートにランクアップします。</div>
         <button class="action craft-opt-btn" id="btnCraftUpgrade" ${upgradeDisabled ? "disabled" : ""}>打ち直す</button>
+      </div>
+      <div class="craft-option" id="craftOptBurn">
+        <div class="craft-opt-title">焼却（EMA3）</div>
+        <div class="craft-opt-desc">不要なエクステ 2 枚を焼却して 💎輝く原石 +1 を獲得。原石は MCHC ショップで Legendary と交換可能。</div>
+        <button class="action craft-opt-btn" id="btnCraftBurn" ${burnDisabled ? "disabled" : ""}>焼却する</button>
       </div>
     </div>
     <button class="craft-leave-btn" id="btnLeaveCraft">← マップに戻る</button>
@@ -3362,9 +3401,73 @@ function openCraftScreen() {
       openCraftUpgrade();
     });
   }
+  const burnBtn = document.getElementById("btnCraftBurn");
+  if (!burnDisabled && burnBtn) {
+    burnBtn.addEventListener("click", () => openCraftBurn());
+  }
   document.getElementById("btnLeaveCraft").addEventListener("click", () => {
     leaveCraft();
   });
+}
+
+// クラフト：焼却（2枚選んで burn → 輝く原石+1）
+function openCraftBurn() {
+  const el = document.getElementById("craftView");
+  if (!el) return;
+  ensureRunState();
+
+  const selected = new Set();
+  const mockS = {
+    playerPhy: LEADER.basePhy, playerInt: LEADER.baseInt, playerAgi: LEADER.baseAgi,
+    enemyPhy: 14, enemyInt: 8,
+    playerHp: runState.playerHp, playerHpMax: runState.playerHpMax,
+    playerGuard: 0, playerShield: 0, energyMax: 3, energy: 3,
+  };
+
+  function render() {
+    el.innerHTML = `<div class="craft-header"><h2>焼却（EMA3）</h2><p class="craft-sub">焼却するエクステを <strong>2 枚</strong> 選択してください。<br>選択中：${selected.size}/2</p></div>`;
+    const list = document.createElement("div");
+    list.style.cssText = "display:flex;flex-wrap:wrap;gap:0.5rem;justify-content:center;margin:0.75rem 0";
+    runState.deck.forEach((card, idx) => {
+      const btn = buildRewardPickButton(card, mockS);
+      btn.style.cssText += selected.has(idx)
+        ? ";outline:3px solid var(--accent);outline-offset:2px;opacity:0.7"
+        : "";
+      btn.addEventListener("click", () => {
+        if (selected.has(idx)) selected.delete(idx);
+        else if (selected.size < 2) selected.add(idx);
+        render();
+      });
+      list.appendChild(btn);
+    });
+    el.appendChild(list);
+
+    const confirm = document.createElement("button");
+    confirm.type = "button";
+    confirm.className = "action primary";
+    confirm.style.cssText = "display:block;margin:0.5rem auto;min-width:200px";
+    confirm.textContent = `この 2 枚を焼却 → 💎+1`;
+    confirm.disabled = selected.size !== 2;
+    confirm.addEventListener("click", () => {
+      const indices = [...selected].sort((a, b) => b - a); // 末尾から削除
+      const burned = [];
+      indices.forEach(i => {
+        burned.push(runState.deck[i].extNameJa);
+        runState.deck.splice(i, 1);
+      });
+      runState.magicStones = (runState.magicStones ?? 0) + 1;
+      clog(`🔥 焼却：${burned.join(' + ')} → 💎 輝く原石 +1（合計 ${runState.magicStones}）`);
+      leaveCraft();
+    });
+    el.appendChild(confirm);
+
+    const back = document.createElement("button");
+    back.className = "craft-leave-btn";
+    back.textContent = "← 戻る";
+    back.addEventListener("click", () => openCraftScreen());
+    el.appendChild(back);
+  }
+  render();
 }
 
 function leaveCraft() {

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -4,6 +4,8 @@ import {
   battleIconUrl,
   CARD_RARITIES,
   CARD_UPGRADE_SERIES,
+  JIN_DEFS,
+  detectActiveJins,
 } from "./cards.js";
 import {
   img,
@@ -931,8 +933,15 @@ function syncResources() {
   if (mchcEl) mchcEl.textContent = String(runState.mchc ?? 0);
   // スカウトランド表示（選択済みなら名前を chapter 表示の脇に追加）
   const chapterEl2 = document.getElementById("chapterVal");
-  if (chapterEl2 && runState.scoutLandName) {
-    chapterEl2.textContent = `${(runState.chapterIdx ?? 0) + 1}・🏳️ ${runState.scoutLandName}`;
+  if (chapterEl2) {
+    let suffix = '';
+    if (runState.scoutLandName) suffix += `・🏳️ ${runState.scoutLandName}`;
+    // JIN 発動状況：デッキスキャンしてラベルを生成
+    const jins = detectActiveJins(runState.deck || []);
+    if (jins.length > 0) {
+      suffix += `・🪄 陣：${jins.map(j => j.name).join('+')}`;
+    }
+    chapterEl2.textContent = `${(runState.chapterIdx ?? 0) + 1}${suffix}`;
   }
   syncLlExtSlots();
   const layerEl = document.getElementById("layerVal");
@@ -1438,6 +1447,14 @@ function startCombatFromMapNode(node) {
     combat.playerPhy += 2;
     combat.playerInt += 2;
   }
+  // JIN（陣）— デッキ内のヒーロー編成を検出して開始時に適用
+  combat.activeJins = detectActiveJins(combat.deck);
+  for (const jin of combat.activeJins) {
+    if (typeof jin.applyAtCombatStart === 'function') {
+      jin.applyAtCombatStart(combat);
+    }
+    clog(`【陣】「${jin.name}」発動：${jin.desc}`);
+  }
 
   // SPEC-005 Phase 2: heroes[] / enemies[] を並行で初期化（Phase 3 で正式に使用、現状は表示・解決用の参照のみ）
   combat.heroes = [makeHeroUnit({
@@ -1817,7 +1834,7 @@ function bindHandTouchDelegation() {
     if (!combat || view !== "combat") { handTouchId = null; return; }
     if (releaseIdx < 0) { clearHandFocus(); handTouchId = null; return; }
     const c = combat.hand[releaseIdx];
-    if (!c || c.cost > combat.energy) { handTouchId = null; return; }
+    if (!c || effectiveCost(c) > combat.energy) { handTouchId = null; return; }
     if (handFocusedIdx === releaseIdx) playCardByRef(c);
     else setHandFocusByIndex(releaseIdx);
     handTouchId = null;
@@ -1841,7 +1858,7 @@ function bindHandCard(el, idx, card) {
     if (!window.matchMedia("(pointer: fine)").matches) return;
     ev.preventDefault();
     if (combatInputLocked) return;
-    if (card.cost > combat.energy || el.classList.contains("card-slot--disabled")) return;
+    if (effectiveCost(card) > combat.energy || el.classList.contains("card-slot--disabled")) return;
     const slots = Array.from(document.querySelectorAll("#hand .card-slot"));
     const myIdx = slots.indexOf(el);
     if (myIdx < 0) return;
@@ -1940,8 +1957,9 @@ function renderCombat() {
   combat.hand.forEach((card, idx) => {
     const slot = document.createElement("div");
     const rarity = CARD_RARITIES[card.libraryKey] || 'common';
-    slot.className = "card-slot" + (card.cost > combat.energy ? " card-slot--disabled" : "");
-    slot.setAttribute("data-cost", String(card.cost));
+    const eCost = effectiveCost(card);
+    slot.className = "card-slot" + (eCost > combat.energy ? " card-slot--disabled" : "");
+    slot.setAttribute("data-cost", String(eCost));
     slot.setAttribute("data-rarity", rarity);
     slot.style.setProperty("--i", String(idx + 1));
     slot.style.setProperty("--n", String(Math.max(n - 1, 1)));
@@ -1953,8 +1971,11 @@ function renderCombat() {
     const detailBody = detailLines.map(t => "<p>" + escapeHtml(t) + "</p>").join("");
     const summaryBody = summaryLines.map(t => "<p>" + escapeHtml(t) + "</p>").join("");
 
+    const costDisplay = (eCost !== card.cost)
+      ? `<span style="text-decoration:line-through;opacity:0.5;font-size:0.7em">${card.cost}</span>${eCost}`
+      : String(card.cost);
     slot.innerHTML =
-      '<div class="card-cost-above"><span class="cost-zeus" aria-hidden="true">⚡</span>' + card.cost + '</div>' +
+      '<div class="card-cost-above"><span class="cost-zeus" aria-hidden="true">⚡</span>' + costDisplay + '</div>' +
       '<div class="card ' + card.type + (card.exhaust ? ' card--exhaust' : '') + '">' +
       '<div class="card-name-hd">' + escapeHtml(card.extNameJa) + (card.exhaust ? '<span class="exhaust-badge" title="消耗：使い切り">🔥</span>' : '') +
       (card.skillNameJa ? '<span class="card-skill-sub">' + escapeHtml(card.skillNameJa) + '</span>' : '') + '</div>' +
@@ -2024,12 +2045,26 @@ async function applyZhangPassive(s) {
   renderCombat();
 }
 
+// JIN（陣）によるコスト割引を含めた実効コスト
+function effectiveCost(card) {
+  if (!card) return 0;
+  let discount = 0;
+  if (combat?.activeJins) {
+    for (const jin of combat.activeJins) {
+      if (typeof jin.applyDiscount === 'function') {
+        discount += jin.applyDiscount(card) || 0;
+      }
+    }
+  }
+  return Math.max(0, (card.cost ?? 0) - discount);
+}
+
 // ─── カードプレイ ─────────────────────────────────────────────────
 async function playCard(idx) {
   if (combatInputLocked) return;
   const card = combat.hand[idx];
-  if (!card || card.cost > combat.energy) return;
-  combat.energy -= card.cost;
+  if (!card || effectiveCost(card) > combat.energy) return;
+  combat.energy -= effectiveCost(card);
   combat.hand.splice(idx, 1);
   // 消耗カードは exhaustPile へ、通常カードは捨て札へ
   if (card.exhaust) {

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -70,6 +70,7 @@ function setCurrentRegulation(id) {
     pendingShopNodeId = null;
     pendingCraftNodeId = null;
     pendingEventNodeId = null;
+    pendingScoutNodeId = null;
     postCombatSnapshot = null;
   }
 }
@@ -166,6 +167,7 @@ let combat = null;
 let pendingShopNodeId = null;
 let pendingCraftNodeId = null;
 let pendingEventNodeId = null;
+let pendingScoutNodeId = null;
 /** @type {'win'|'lose'|null} */
 let cutinKind = null;
 let cutinResolve = null;
@@ -646,10 +648,11 @@ function dealPhySkillToEnemy(s, skillPct) {
   let vuln = s.enemyVulnerable || 0;
   let total = base + critBonus + vuln;
   s.enemyVulnerable = 0;
-  // 出血（敵が出血スタックを持つとき、被物理攻撃で追加ダメージ）
+  // 出血（敵が出血スタックを持つとき、被物理攻撃で追加ダメージ）— Graphite ランド：+1 ボーナス
   if ((s.enemyBleed || 0) > 0) {
-    total += s.enemyBleed;
-    clog(`出血 ×${s.enemyBleed} 追加`);
+    const graphiteBonus = runState?.scoutLand === 'graphite' ? 1 : 0;
+    total += s.enemyBleed + graphiteBonus;
+    clog(`出血 ×${s.enemyBleed}${graphiteBonus ? ' +1⟨Graphite⟩' : ''} 追加`);
   }
   total = applyGuardToDamage("enemy", total);
   s.enemyHp = Math.max(0, s.enemyHp - total);
@@ -926,6 +929,11 @@ function syncResources() {
   if (cpEl) cpEl.textContent = String(runState.cp ?? 0);
   const mchcEl = document.getElementById("mchcVal");
   if (mchcEl) mchcEl.textContent = String(runState.mchc ?? 0);
+  // スカウトランド表示（選択済みなら名前を chapter 表示の脇に追加）
+  const chapterEl2 = document.getElementById("chapterVal");
+  if (chapterEl2 && runState.scoutLandName) {
+    chapterEl2.textContent = `${(runState.chapterIdx ?? 0) + 1}・🏳️ ${runState.scoutLandName}`;
+  }
   syncLlExtSlots();
   const layerEl = document.getElementById("layerVal");
   if (layerEl) {
@@ -1072,7 +1080,8 @@ function renderMap() {
       node.type === "rest"   ? "HP回復" :
       node.type === "shop"   ? "ショップ" :
       node.type === "craft"  ? "クラフト" :
-      node.type === "event"  ? "？イベント" : "ボス";
+      node.type === "event"  ? "？イベント" :
+      node.type === "scout"  ? "スカウト掲示板" : "ボス";
     g.appendChild(ty);
     const allowed = new Set(reachableNextNodeIds(runState.lastMapNodeId));
     if (!allowed.has(node.id)) g.style.pointerEvents = "none";
@@ -1176,7 +1185,9 @@ function tryEnterMapNode(nodeId) {
   const node = mapNodeById(nodeId);
   if (!node) return;
   if (node.type === "rest") {
-    const heal = Math.floor(runState.playerHpMax * 0.35);
+    // Ocean ランド：ヒール +20%
+    const healPct = runState.scoutLand === 'ocean' ? 0.42 : 0.35;
+    const heal = Math.floor(runState.playerHpMax * healPct);
     const actualHeal = Math.min(runState.playerHpMax, runState.playerHp + heal) - runState.playerHp;
     runState.playerHp = Math.min(runState.playerHpMax, runState.playerHp + heal);
     runState.cp = (runState.cp ?? 0) + 1;  // 休憩で Cp+1
@@ -1209,6 +1220,11 @@ function tryEnterMapNode(nodeId) {
   if (node.type === "event") {
     pendingEventNodeId = nodeId;
     openEventScreen();
+    return;
+  }
+  if (node.type === "scout") {
+    pendingScoutNodeId = nodeId;
+    openScoutScreen();
     return;
   }
   // ボス突入前の MCHC ショップ：MCHC を持っていれば LL ext と交換できる
@@ -1303,6 +1319,8 @@ function showView(name) {
   if (cv) cv.classList.toggle("hidden", name !== "craft");
   const ev = document.getElementById("eventView");
   if (ev) ev.classList.toggle("hidden", name !== "event");
+  const sv2 = document.getElementById("scoutView");
+  if (sv2) sv2.classList.toggle("hidden", name !== "scout");
   const hsv = document.getElementById("heroSelectView");
   if (hsv) hsv.classList.toggle("hidden", name !== "heroSelect");
   const rsv = document.getElementById("regulationSelectView");
@@ -1356,7 +1374,11 @@ function startCombatFromMapNode(node) {
 
   // レギュレーション効果適用 (#37)
   const reg = getCurrentRegulation();
-  const regHp = Math.max(1, Math.round(enemyDef.hp * reg.effects.hpFactor));
+  let regHp = Math.max(1, Math.round(enemyDef.hp * reg.effects.hpFactor));
+  // Ruby ランド：エリート敵 HP -10%
+  if (runState.scoutLand === 'ruby' && node.elite) {
+    regHp = Math.max(1, Math.round(regHp * 0.9));
+  }
   const regPhy = Math.max(1, Math.round(enemyDef.phy * reg.effects.atkFactor));
   const regInt = Math.max(1, Math.round(enemyDef.int * reg.effects.atkFactor));
 
@@ -1405,6 +1427,15 @@ function startCombatFromMapNode(node) {
     hasResurrection: false,
     _lastUi: null,
   };
+  // Strawberry ランド：戦闘開始時にガード+5
+  if (runState.scoutLand === 'strawberry') {
+    combat.playerGuard += 5;
+  }
+  // Grape ランド：戦闘開始時 PHY+2 / INT+2
+  if (runState.scoutLand === 'grape') {
+    combat.playerPhy += 2;
+    combat.playerInt += 2;
+  }
 
   // SPEC-005 Phase 2: heroes[] / enemies[] を並行で初期化（Phase 3 で正式に使用、現状は表示・解決用の参照のみ）
   combat.heroes = [makeHeroUnit({
@@ -1551,12 +1582,13 @@ function startPlayerTurn() {
     checkResurrection(combat);
     if (combat.playerHp <= 0) { endCombatLoss(); return; }
   }
-  // 毒ティック（敵）
+  // 毒ティック（敵）— Graphite ランド：+1 ボーナス
   if ((combat.enemyPoison || 0) > 0) {
-    const dmg = combat.enemyPoison;
+    const graphiteBonus = runState?.scoutLand === 'graphite' ? 1 : 0;
+    const dmg = combat.enemyPoison + graphiteBonus;
     combat.enemyHp = Math.max(0, combat.enemyHp - dmg);
     flashPortrait("enemy"); playPortraitEffect("enemy", "debuff");
-    clog(`毒ダメージ（敵）${dmg}`);
+    clog(`毒ダメージ（敵）${dmg}${graphiteBonus ? ' ⟨Graphite +1⟩' : ''}`);
     if (combat.enemyHp <= 0) { endCombatWin(); return; }
   }
 
@@ -1583,7 +1615,9 @@ function startPlayerTurn() {
 
   combat.energy = combat.energyMax + (combat.bonusEnergyNext || 0);
   combat.bonusEnergyNext = 0;
-  const drawN = 5;
+  // Lime ランド：戦闘開始時の手札 +1（最初のターンのみ）
+  let drawN = 5;
+  if (combat.turn === 1 && runState?.scoutLand === 'lime') drawN += 1;
   drawCards(combat, drawN);
   advanceEnemyIntent();
   renderCombat();
@@ -2142,7 +2176,9 @@ function endCombatWin() {
   const isElite = combat.isElite;
 
   // GUM
-  const earnedGold = isBoss ? chapter.bossRewardGold : isElite ? 45 : 28;
+  let earnedGold = isBoss ? chapter.bossRewardGold : isElite ? 45 : 28;
+  // Blueberry ランド：戦闘勝利時 GUM +5
+  if (runState.scoutLand === 'blueberry') earnedGold += 5;
   gold += earnedGold;
 
   // MCHC：エリート +1 / ボス +2（高難度ノード突破でドロップ）
@@ -2152,6 +2188,13 @@ function endCombatWin() {
     clog(`勝利！ GUM +${earnedGold}・💠 MCHC +${earnedMchc}`);
   } else {
     clog(`勝利！ GUM +${earnedGold}`);
+  }
+
+  // Sage ランド：戦闘勝利時 HP+3（snapshot に反映されるよう combat 側を増やす）
+  if (runState.scoutLand === 'sage') {
+    const before = combat.playerHp;
+    combat.playerHp = Math.min(combat.playerHpMax, combat.playerHp + 3);
+    if (combat.playerHp > before) clog(`Sage の知恵：HP +${combat.playerHp - before}`);
   }
 
   // 報酬カードプール（累積）
@@ -2778,17 +2821,24 @@ function openShop() {
     buyBtn.className = "shop-buy-btn action";
     buyBtn.textContent = "購入する";
     buyBtn.addEventListener("click", () => {
-      if (gold < price) { clog("GUM が足りません"); return; }
-      gold -= price;
       ensureRunState();
+      // 流星街ランド：ラン中で最初の購入が無料
+      const isMeteorFree = runState.meteorFirstFree === true;
+      if (!isMeteorFree && gold < price) { clog("GUM が足りません"); return; }
+      if (isMeteorFree) {
+        runState.meteorFirstFree = false;
+        clog(`🌌 流星街の権利：${def.extNameJa} を無料で獲得`);
+      } else {
+        gold -= price;
+      }
       runState.deck.push(copyCard(key));
       buyBtn.disabled = true;
-      buyBtn.textContent = "購入済み";
+      buyBtn.textContent = isMeteorFree ? "獲得済み（無料）" : "購入済み";
       if (goldDisp) goldDisp.textContent = String(gold);
       playSeShopBuy();
       syncResources();
-      clog(`購入: ${def.extNameJa}`);
-      renderNavigator(`「${def.extNameJa}」を購入しました！デッキが強化されましたよ！`);
+      clog(`購入: ${def.extNameJa}${isMeteorFree ? '（無料）' : ''}`);
+      renderNavigator(`「${def.extNameJa}」を${isMeteorFree ? '入手' : '購入'}しました！デッキが強化されましたよ！`);
     });
     item.appendChild(buyBtn);
 
@@ -2911,6 +2961,8 @@ function resetRun() {
   clearedChapters = new Set();
   pendingShopNodeId = null;
   pendingCraftNodeId = null;
+  pendingEventNodeId = null;
+  pendingScoutNodeId = null;
   postCombatSnapshot = null;
   stopBgm();
   dismissCutin();
@@ -2928,6 +2980,8 @@ function startRunFromChapter(chapterIdx) {
   combat = null;
   pendingShopNodeId = null;
   pendingCraftNodeId = null;
+  pendingEventNodeId = null;
+  pendingScoutNodeId = null;
   postCombatSnapshot = null;
   const chapter = CHAPTERS[chapterIdx];
   const { nodes, edges, viewH, startY } = generateChapterMap(chapter, ENEMY_DEFS);
@@ -3323,6 +3377,92 @@ function leaveEvent() {
     runState.pathNodeIds.push(pendingEventNodeId);
     runState.lastMapNodeId = pendingEventNodeId;
     pendingEventNodeId = null;
+  }
+  syncResources();
+  showView("map");
+  renderMap();
+}
+
+// ─── スカウト掲示板（9 ランド + 流星街 = 10 国のパッシブ） ─────────
+/**
+ * 元タイトル「ランド勧誘」のリスペクト。
+ * runState.scoutLand に選んだ ID が入る。各 ID に対する効果は applyScout* 関数群。
+ */
+const SCOUT_LANDS = [
+  { id: 'ocean',      name: 'Ocean',      color: '#3aa6ff', flavor: '初代キング Elvis さん',     desc: 'ヒール+20%（休憩・回復系の効果が +20%）' },
+  { id: 'strawberry', name: 'Strawberry', color: '#ff5c7a', flavor: 'ファオ帝国・初代統一国',     desc: '戦闘開始時にガード+5' },
+  { id: 'tangerine',  name: 'Tangerine',  color: '#ff9b3d', flavor: 'マエストロのギブアウェイ',   desc: 'ラン開始時に GUM +30（既に経過していても遡って付与）' },
+  { id: 'lime',       name: 'Lime',       color: '#7ed957', flavor: '初代キング yamap さん',      desc: '戦闘開始時の手札 +1' },
+  { id: 'graphite',   name: 'Graphite',   color: '#444444', flavor: '黒系（毒・出血）の聖地',     desc: '毒・出血ティック ダメージ +1' },
+  { id: 'grape',      name: 'Grape',      color: '#9c5ad9', flavor: 'バフ・支援に強いランド',     desc: '戦闘開始時に PHY +2, INT +2（バフを纏った状態でスタート）' },
+  { id: 'sage',       name: 'Sage',       color: '#7bbf7b', flavor: '賢者の知恵',                 desc: '戦闘勝利時に HP +3' },
+  { id: 'blueberry',  name: 'Blueberry',  color: '#4d6cff', flavor: 'チキン海賊団の本拠',         desc: '戦闘勝利時に GUM +5' },
+  { id: 'ruby',       name: 'Ruby',       color: '#d63031', flavor: '団長ロアの源流',             desc: 'エリート敵の HP -10%' },
+  { id: 'meteor',     name: '流星街',     color: '#7c2a2a', flavor: '初心者に一番お勧めしないランド', desc: '最初のショップ：1枚目の購入が無料' },
+];
+
+function openScoutScreen() {
+  showView("scout");
+  const el = document.getElementById("scoutView");
+  if (!el) return;
+  ensureRunState();
+
+  if (runState.scoutLand) {
+    // すでに選択済みの場合は休憩扱い
+    el.innerHTML = `
+      <div class="craft-header">
+        <h2>スカウト掲示板（選択済）</h2>
+        <p class="craft-sub">既に「${runState.scoutLand}」を選択しています。同じ掲示板は2度使えません。</p>
+      </div>
+      <button class="craft-leave-btn" id="btnLeaveScout2">← マップに戻る</button>
+    `;
+    document.getElementById("btnLeaveScout2").addEventListener("click", leaveScout);
+    return;
+  }
+
+  el.innerHTML = `
+    <div class="craft-header">
+      <h2>スカウト掲示板</h2>
+      <p class="craft-sub">所属ランドを選んでください。選んだ国の文化が、この後のラン全体に影響します。<br><span style="color:var(--muted);font-size:0.85em">※ ラン中1度だけ選択可能</span></p>
+    </div>
+  `;
+  const list = document.createElement("div");
+  list.style.cssText = "display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:0.5rem;margin:0.75rem 0";
+  SCOUT_LANDS.forEach(land => {
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className = "action";
+    card.style.cssText =
+      `text-align:left;padding:0.6rem 0.75rem;background:var(--card-bg);border-left:4px solid ${land.color};border-radius:6px;cursor:pointer`;
+    card.innerHTML = `
+      <div style="font-weight:700;color:${land.color}">${land.name}</div>
+      <div style="font-size:0.75rem;color:var(--muted);margin:0.15rem 0">${land.flavor}</div>
+      <div style="font-size:0.85rem">${land.desc}</div>
+    `;
+    card.addEventListener("click", () => {
+      runState.scoutLand = land.id;
+      runState.scoutLandName = land.name;
+      // tangerine: GUM +30（即時付与）
+      if (land.id === 'tangerine') {
+        gold += 30;
+        clog('🍊 Tangerine ギブアウェイ：GUM +30');
+      }
+      // meteor: 最初のショップ 1枚目無料
+      if (land.id === 'meteor') runState.meteorFirstFree = true;
+      clog(`🏳️ ランド「${land.name}」に所属：${land.desc}`);
+      leaveScout();
+    });
+    list.appendChild(card);
+  });
+  el.appendChild(list);
+}
+
+function leaveScout() {
+  ensureRunState();
+  if (pendingScoutNodeId) {
+    runState.pathNodeIds.push(pendingScoutNodeId);
+    runState.lastMapNodeId = pendingScoutNodeId;
+    pendingScoutNodeId = null;
   }
   syncResources();
   showView("map");

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -69,6 +69,7 @@ function setCurrentRegulation(id) {
     gold = 75;
     pendingShopNodeId = null;
     pendingCraftNodeId = null;
+    pendingEventNodeId = null;
     postCombatSnapshot = null;
   }
 }
@@ -164,6 +165,7 @@ let runState = null;
 let combat = null;
 let pendingShopNodeId = null;
 let pendingCraftNodeId = null;
+let pendingEventNodeId = null;
 /** @type {'win'|'lose'|null} */
 let cutinKind = null;
 let cutinResolve = null;
@@ -1069,7 +1071,8 @@ function renderMap() {
       node.type === "fight"  ? (node.elite ? "レアエネミー" : "エネミー") :
       node.type === "rest"   ? "HP回復" :
       node.type === "shop"   ? "ショップ" :
-      node.type === "craft"  ? "クラフト" : "ボス";
+      node.type === "craft"  ? "クラフト" :
+      node.type === "event"  ? "？イベント" : "ボス";
     g.appendChild(ty);
     const allowed = new Set(reachableNextNodeIds(runState.lastMapNodeId));
     if (!allowed.has(node.id)) g.style.pointerEvents = "none";
@@ -1101,6 +1104,7 @@ function renderMap() {
     if (node.type === "shop")  iconUrl = img("Image/Icons/gum.png");
     else if (node.type === "rest")  iconUrl = img("Image/BattleIcons/Parameters/hp.png");
     else if (node.type === "craft") iconUrl = img("Image/Icons/ce.png");
+    // event は文字「？」ラベルで表現するためアイコン省略
     if (!iconUrl) continue;
     const sz = 5.2;
     const iconEl = document.createElementNS("http://www.w3.org/2000/svg", "image");
@@ -1202,6 +1206,11 @@ function tryEnterMapNode(nodeId) {
     openCraftScreen();
     return;
   }
+  if (node.type === "event") {
+    pendingEventNodeId = nodeId;
+    openEventScreen();
+    return;
+  }
   // ボス突入前の MCHC ショップ：MCHC を持っていれば LL ext と交換できる
   if (node.type === "boss" && (runState.mchc ?? 0) >= 1 && runState.llExtSlots.some(s => s === null)) {
     openMchcShopModal(() => startCombatFromMapNode(node));
@@ -1292,6 +1301,8 @@ function showView(name) {
   if (nsv) nsv.classList.toggle("hidden", name !== "nodeSelect");
   const cv = document.getElementById("craftView");
   if (cv) cv.classList.toggle("hidden", name !== "craft");
+  const ev = document.getElementById("eventView");
+  if (ev) ev.classList.toggle("hidden", name !== "event");
   const hsv = document.getElementById("heroSelectView");
   if (hsv) hsv.classList.toggle("hidden", name !== "heroSelect");
   const rsv = document.getElementById("regulationSelectView");
@@ -2166,6 +2177,9 @@ function endCombatWin() {
     isBoss,
   };
   combat = null;
+
+  // ナーフ系イベントの適用（戦闘終了後）— 武田信玄調整事件など
+  applyPendingNerfs();
 
   // ─── LLエクステ ドロップ判定（ホレリス以降、章インデックス >= 1） ───
   let droppedLlExt = null;
@@ -3219,6 +3233,126 @@ function leaveCraft() {
   }
   showView("map");
   renderMap();
+}
+
+// ─── ？イベント画面 ──────────────────────────────────────────────
+/**
+ * ？ノードのイベントプール。元タイトルの史実イベントから取材したフレーバー。
+ * 各エントリ: { id, weight, title, body, options: [{ label, accept(runState) }] }
+ */
+const EVENT_POOL = [
+  {
+    id: "shingen-nerf",
+    weight: 5,
+    title: "武田信玄調整事件",
+    body:
+      "強力な能力を持つ「武田信玄（暫定版）」が手元に流れ着いた。\n" +
+      "しかし運営曰く「あまりに強すぎる」――次の戦闘終了後にナーフが入ることが告知されている…\n\n" +
+      "（最大HPの25%固定でPHYバフ → 戦闘1回後、10〜25%ランダムへ修正）",
+    options: [
+      {
+        label: "受け取る（1戦のみ強い）",
+        accept(rs) {
+          rs.deck.push(copyCard("cardShingenPre"));
+          rs.shingenPending = true;
+          clog("✨「武田信玄（暫定版）」をデッキに追加（次戦闘後にナーフ予定）");
+        },
+      },
+      {
+        label: "見送る",
+        accept() {
+          clog("武田信玄を見送った（賢明な判断）");
+        },
+      },
+    ],
+  },
+];
+
+function pickEvent() {
+  const total = EVENT_POOL.reduce((s, e) => s + (e.weight ?? 1), 0);
+  let r = Math.random() * total;
+  for (const e of EVENT_POOL) {
+    r -= e.weight ?? 1;
+    if (r <= 0) return e;
+  }
+  return EVENT_POOL[0];
+}
+
+function openEventScreen() {
+  showView("event");
+  const el = document.getElementById("eventView");
+  if (!el) return;
+  ensureRunState();
+
+  // 同一ノードでの再選択を防ぐためイベント抽選を runState に保持
+  if (!runState.eventSeeds) runState.eventSeeds = {};
+  if (pendingEventNodeId && !runState.eventSeeds[pendingEventNodeId]) {
+    runState.eventSeeds[pendingEventNodeId] = pickEvent().id;
+  }
+  const eventId = pendingEventNodeId
+    ? runState.eventSeeds[pendingEventNodeId]
+    : pickEvent().id;
+  const ev = EVENT_POOL.find(e => e.id === eventId) || EVENT_POOL[0];
+
+  el.innerHTML = `
+    <div class="craft-header">
+      <h2>？ ${ev.title}</h2>
+      <p class="craft-sub" style="white-space:pre-line">${ev.body}</p>
+    </div>
+  `;
+  const choices = document.createElement("div");
+  choices.className = "craft-choices";
+  choices.style.cssText = "display:flex;flex-direction:column;gap:0.5rem;margin:1rem 0";
+  ev.options.forEach(opt => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "action craft-opt-btn";
+    btn.textContent = opt.label;
+    btn.addEventListener("click", () => {
+      opt.accept(runState);
+      leaveEvent();
+    });
+    choices.appendChild(btn);
+  });
+  el.appendChild(choices);
+}
+
+function leaveEvent() {
+  ensureRunState();
+  if (pendingEventNodeId) {
+    runState.pathNodeIds.push(pendingEventNodeId);
+    runState.lastMapNodeId = pendingEventNodeId;
+    pendingEventNodeId = null;
+  }
+  syncResources();
+  showView("map");
+  renderMap();
+}
+
+/**
+ * 戦闘終了時に呼ばれる：保留中のナーフ系効果を適用する
+ * 武田信玄調整事件：deck 内の cardShingenPre を cardShingenPost に置換
+ */
+function applyPendingNerfs() {
+  ensureRunState();
+  if (!runState.shingenPending) return;
+  const before = runState.deck.length;
+  let replaced = 0;
+  runState.deck = runState.deck.map(c => {
+    if (c.libraryKey === "cardShingenPre") {
+      replaced++;
+      return copyCard("cardShingenPost");
+    }
+    return c;
+  });
+  runState.shingenPending = false;
+  if (replaced > 0) {
+    clog(`📢 ナーフ通知：「武田信玄（暫定版）」×${replaced} → ナーフ後バージョンへ修正されました`);
+    if (before === runState.deck.length) {
+      // navigator hint
+      renderNavigator(`武田信玄が運営から修正を受けました…（${replaced}枚を再調整）`);
+    }
+  }
 }
 
 function openCraftGetCard() {

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -36,6 +36,12 @@ import { CHAPTERS } from "./chapters.js";
 import { generateChapterMap } from "./maps.js";
 import { LL_EXT_POOL } from "./ll-extensions.js";
 import {
+  ACHIEVEMENTS,
+  tryUnlock as tryUnlockAchievement,
+  recordVisitedLand,
+  openAchievementsModal,
+} from "./achievements.js";
+import {
   resolveTargets,
   makeHeroUnit,
   makeEnemyUnit,
@@ -1298,6 +1304,7 @@ function openMchcShopModal(onClose) {
             const slot = runState.llExtSlots.findIndex(s => s === null);
             if (slot >= 0) runState.llExtSlots[slot] = ll;
             clog(`💠 MCHC -1：「${ll.name}」を Legendary 枠に獲得`);
+            tryUnlockAchievement('mchc-shop-buy');
             syncResources();
             renderShop();
           });
@@ -1486,6 +1493,7 @@ function startCombatFromMapNode(node) {
     }
     clog(`【陣】「${jin.name}」発動：${jin.desc}`);
   }
+  if (combat.activeJins.length > 0) tryUnlockAchievement('jin-active');
 
   // SPEC-005 Phase 2: heroes[] / enemies[] を並行で初期化（Phase 3 で正式に使用、現状は表示・解決用の参照のみ）
   combat.heroes = [makeHeroUnit({
@@ -2263,15 +2271,18 @@ function endCombatWin() {
       runState.deck.push(copyCard("cardChocoFragment"));
       clog("🍫 「チョコ片」を入手！（耐久勝利の証）");
       renderNavigator("ヨシュカ・チョコの30ターン耐久に成功しました！「チョコ片」をデッキに追加しました。");
+      tryUnlockAchievement('yoshiko-choco-endured');
     } else if (isChoco) {
       // 通常撃破は基本起こらないが、念のため
       runState.deck.push(copyCard("cardChocoFragment"));
       clog("🍫 まさかの撃破！「チョコ片」を入手");
+      tryUnlockAchievement('yoshiko-choco-endured');
     } else {
       // ヨシュカ通常撃破：報酬は微妙な GUM のみ
       gold += 12;
       clog("🍵 ヨシュカ撃破：GUM +12（…報酬は微妙）");
       renderNavigator("ヨシュカは弱すぎて1日で討伐されました。報酬は微妙でしたね…");
+      tryUnlockAchievement('yoshiko-defeated');
     }
     runState.activeInterlude = null;
     combat = null;
@@ -2430,6 +2441,12 @@ function advanceAfterRewardPick(libraryKey) {
       postCombatSnapshot = null;
       if (runState.runComplete) {
         // 全章クリア → ゲームオーバー画面（クリア）
+        tryUnlockAchievement('first-clear');
+        // 武田信玄ナーフ後カードを含むデッキでクリア → 専用実績
+        const hasShingen = runState.deck.some(
+          c => c.libraryKey === 'cardShingenPre' || c.libraryKey === 'cardShingenPost'
+        );
+        if (hasShingen) tryUnlockAchievement('shingen-clear');
         lastReportSnapshot = captureRunSnapshot({ isCleared: true, defeatedBy: null });
         showView("over");
         document.getElementById("gameOverMsg").textContent =
@@ -3457,6 +3474,7 @@ function openCraftBurn() {
       });
       runState.magicStones = (runState.magicStones ?? 0) + 1;
       clog(`🔥 焼却：${burned.join(' + ')} → 💎 輝く原石 +1（合計 ${runState.magicStones}）`);
+      tryUnlockAchievement('ema3-burn');
       leaveCraft();
     });
     el.appendChild(confirm);
@@ -3642,6 +3660,8 @@ function openScoutScreen() {
       // meteor: 最初のショップ 1枚目無料
       if (land.id === 'meteor') runState.meteorFirstFree = true;
       clog(`🏳️ ランド「${land.name}」に所属：${land.desc}`);
+      // ラン横断で全ランド達成（実績）
+      recordVisitedLand(land.id);
       leaveScout();
     });
     list.appendChild(card);
@@ -3928,6 +3948,14 @@ function init() {
     titleEl.addEventListener("click", dismissTitle);
     titleEl.addEventListener("keydown", (ev) => {
       if (ev.key === "Enter" || ev.key === " ") dismissTitle();
+    });
+  }
+  // 実績ボタン（タイトル画面の上から押せる、伝播は止める）
+  const btnAch = document.getElementById("btnTitleAchievements");
+  if (btnAch) {
+    btnAch.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      openAchievementsModal();
     });
   }
   // ヘッダーアイコン (#37) を初期化

--- a/prototype/js/maps.js
+++ b/prototype/js/maps.js
@@ -27,7 +27,8 @@ function evenlySpaced(n, min, max) {
 function makeTypePicker(nodeRatios) {
   const pool = [];
   for (const [type, weight] of Object.entries(nodeRatios)) {
-    const resolved = type === 'event' ? 'rest' : type === 'craft' ? 'craft' : type;
+    // event は独立ノード化（B-3 武田信玄調整事件など、? アイコン）。craft / その他はそのまま
+    const resolved = type === 'craft' ? 'craft' : type;
     const count = Math.max(1, Math.round(weight * 20));
     for (let i = 0; i < count; i++) pool.push(resolved);
   }
@@ -36,7 +37,15 @@ function makeTypePicker(nodeRatios) {
 
 /** ノード種別の表示ラベル */
 function labelForType(type) {
-  return { fight: 'エネミー', rest: '休憩', shop: 'ショップ', elite: 'レアエネミー', boss: 'ボス', craft: 'クラフト' }[type] ?? '?';
+  return {
+    fight: 'エネミー',
+    rest: '休憩',
+    shop: 'ショップ',
+    elite: 'レアエネミー',
+    boss: 'ボス',
+    craft: 'クラフト',
+    event: '？イベント',
+  }[type] ?? '?';
 }
 
 /**

--- a/prototype/js/maps.js
+++ b/prototype/js/maps.js
@@ -45,6 +45,7 @@ function labelForType(type) {
     boss: 'ボス',
     craft: 'クラフト',
     event: '？イベント',
+    scout: 'スカウト',
   }[type] ?? '?';
 }
 
@@ -184,6 +185,16 @@ export function generateChapterMap(chapter, enemyDefs = {}) {
   // エッジ: 各層 → 次層（隣接のみ）
   for (let l = 0; l < layerNodes.length - 1; l++) {
     edges.push(...connectLayersAdjacent(layerNodes[l], layerNodes[l + 1]));
+  }
+
+  // 各章に最大 1 個「スカウト掲示板」ノードを配置（既存 rest を置換）
+  // 元タイトル「ランド勧誘」のリスペクト。プレイヤーがランドを選んでパッシブを得る
+  const restNodes = nodes.filter(n => n.type === 'rest');
+  if (restNodes.length >= 2) {
+    // 真ん中あたりの rest を scout に転換
+    const target = restNodes[Math.floor(restNodes.length / 2)];
+    target.type = 'scout';
+    target.label = 'スカウト';
   }
 
   return { nodes, edges, viewH, startY };


### PR DESCRIPTION
## Summary

MyCryptoHeroes 派生として、元タイトルプレイヤーがニヤッとするゲーム的小ネタを 8 件まとめて実装。
各機能は独立したコミットで、必要に応じて部分採用も可能。

| Commit | 元ネタ | 内容 |
|---|---|---|
| **A-4** | ノード Ver 1.1〜1.8 の更新履歴 | 各章にextシリーズ＆エコ世代フレーバー（マップヘッダー表示のみ） |
| **A-3** | Lab／Eco 3.0／MCHC | 通貨 3 層化：GUM＋Cp（休憩・クラフト用）＋MCHC（エリート/ボス入手→ボス前 Legendary ショップ） |
| **B-3** | 2019/2 武田信玄ナーフ事案 | `？` イベントノード新設。武田信玄（暫定版）入手 → 1戦闘後に10〜25%ランダムへ自動ナーフ |
| **B-6** | 9 ランド + 流星街 | スカウト掲示板：Ocean/Strawberry/Tangerine/Lime/Graphite/Grape/Sage/Blueberry/Ruby/流星街 各固有パッシブ |
| **B-4** | 初代レイド「よしこ」→ 2nd レイド「チョコ」 | 章間レイド：ヨシュカ（弱すぎ）／ヨシュカ・チョコ（HP999・30ターン耐久勝利でチョコ片獲得） |
| **C-1** | JINβ（2019） | 6 ヒーローカード追加 + 陣システム。三国志陣（PHY 攻撃 -1コスト）／西洋革命陣（致死耐性） |
| **C-3** | EMA3（2023 ext burn → 魔石） | クラフトに焼却追加。2枚 burn → 💎+1。MCHC ショップで 💎×2 = LL 1枠と交換 |
| **C-2** | 2023 Achievement リリース | localStorage で 8 種実績を永続化。タイトル画面右上の🏆ボタンから一覧 |

## アーキテクチャ変更点

- マップノード型に `event` `scout` を追加（従来 `event` は `rest` に折り畳まれていた）
- `runState` 拡張：`cp` `mchc` `magicStones` `scoutLand` `eventSeeds` `shingenPending` `yoshikoCleared` `yoshikoChocoCleared`
- `combat` 拡張：`activeJins` `enduranceTurns` ／ `effectiveCost(card)` で陣割引適用
- `bossOverrideId` で `startCombatFromMapNode` を再利用して章間レイドを起動（chapter 変数の mutation を回避）
- 新ファイル：`prototype/js/achievements.js`

## Test plan

Vercel プレビューで以下を確認：

- [ ] タイトル画面に🏆実績ボタンが出て、開閉できる
- [ ] マップヘッダーに「Ver 1.x・era：weapon series」が見える
- [ ] リソースバーに GUM／💠 MCHC／Cp／💎 原石が並ぶ
- [ ] スカウトノード（？マーク）でランド選択ができ、🏳️ がリソースバーに出る
- [ ] エリート/ボス撃破で MCHC が増える
- [ ] ボス突入時に MCHC ≥ 1 または 💎 ≥ 2 ならショップモーダルが出る
- [ ] ？ イベントノードで「武田信玄調整事件」発生 → 受け取り → 次戦闘後にナーフされる
- [ ] 章 1 ボス撃破後に章間レイド「ヨシュカ」、章 2 ボス撃破後に「ヨシュカ・チョコ」
- [ ] チョコ戦：30ターン耐え切ると勝利 + チョコ片獲得
- [ ] デッキに張遼+呂布+趙雲 揃うと「🪄 陣：三国志陣」が表示され、PHY 攻撃カードのコストが -1 表示
- [ ] クラフトの「焼却」で 2 枚選んで 💎 +1
- [ ] 全章クリアで実績解放トースト

## 既知のスコープ外

- ？イベントは現状「武田信玄調整事件」1 件のみ（プール拡張は次フェーズ）
- バランスシム未走（balance-sim/iter-012〜 は別 PR で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)