### PR TITLE
docs(SPEC-006): §7.1.1 TargetSpec → 表示ラベル対応表を確定

### DIFF
--- a/docs/specs/SPEC-006-card-caster.md
+++ b/docs/specs/SPEC-006-card-caster.md
@@ -162,8 +162,77 @@ libraryKey, extId, extNameJa, skillNameJa, skillIcon, cost, type, caster, effect
 ```
 
 - **キャスター表示エリア**: エクステ画像の右下に重ねて配置。バトル中は **解決された個別ヒーローの portrait**。アイコン下にキャスターロール（"先頭" 等の小ラベル）を併記
-- **効果エリア**: 縦に 1 〜 N 行（カード設計時の `effects` 配列）。左カラムにターゲット (色付きピル: 自身=緑 / 味方=緑 / 敵=赤)、右カラムに係数テキスト
+- **効果エリア**: 縦に 1 〜 N 行（カード設計時の `effects` 配列）。左カラム (約 60-80px 幅) にターゲットラベル (色付きピル)、右カラムに係数テキスト
 - **解決不能カード**（caster が全員死亡）: 全体グレーアウト + クリック無効。コスト不足と同じ視覚処理を流用
+
+#### 7.1.1 TargetSpec → 表示ラベル対応表
+
+カード効果行の左カラムに表示する各 TargetSpec のラベル定義。SPEC-005 §6 のターゲット仕様語彙を全網羅し、現状未使用の TargetSpec も将来の Epic / Legendary カードや派生作で使用される前提で確定。
+
+**色定義 (CSS 変数として `prototype/index.html` に追加)**:
+
+```css
+:root {
+  --target-ally: #7ed957;   /* 味方系 = 緑 */
+  --target-enemy: #e76060;  /* 敵系 = 赤 */
+  --target-all: #c47ed9;    /* 全体系 = 紫 (--accent #c4a35a 金との視認区別) */
+  --target-self: #5ab4c4;   /* 自身 = シアン (--energy と同色, "自分" 概念で統一) */
+}
+```
+
+**ラベル対応表 (左カラム約 60-80px / 日本語 3-4 文字基準)**:
+
+| TargetSpec | 表示ラベル | 色変数 | 想定使用頻度 (現状/将来) |
+|---|---|---|---|
+| `self` | 自身 | `--target-self` | 多 / 多 |
+| `ally.front` | 味方前 | `--target-ally` | 0 / 中 |
+| `ally.mid` | 味方中 | `--target-ally` | 0 / 中 |
+| `ally.back` | 味方後 | `--target-ally` | 0 / 中 |
+| `ally.foremost` | 味方先 | `--target-ally` | 0 / 中 |
+| `ally.rearmost` | 味方尾 | `--target-ally` | 0 / 低 |
+| `ally.all` | 味方全 | `--target-ally` | 0 / 多 |
+| `ally.random` | 味方ランダム | `--target-ally` | 0 / 低 |
+| `ally.highest_phy` | 味PHY↑ | `--target-ally` | 0 / 低 |
+| `ally.lowest_phy` | 味PHY↓ | `--target-ally` | 0 / 低 |
+| `ally.highest_int` | 味INT↑ | `--target-ally` | 0 / 低 |
+| `ally.lowest_int` | 味INT↓ | `--target-ally` | 0 / 低 |
+| `ally.highest_hp` | 味HP↑ | `--target-ally` | 0 / 低 |
+| `ally.lowest_hp` | 味HP↓ | `--target-ally` | 0 / 中 |
+| `enemy.front` | 敵前 | `--target-enemy` | 0 / 中 |
+| `enemy.mid` | 敵中 | `--target-enemy` | 0 / 中 |
+| `enemy.back` | 敵後 | `--target-enemy` | 0 / 中 |
+| `enemy.foremost` | 敵先頭 | `--target-enemy` | **多 (392 / 924)** / 多 |
+| `enemy.rearmost` | 敵最後尾 | `--target-enemy` | 0 / 中 |
+| `enemy.all` | 敵全 | `--target-enemy` | 0 / 多 |
+| `enemy.random` | 敵ランダム | `--target-enemy` | 0 / 低 |
+| `enemy.highest_phy` | 敵PHY↑ | `--target-enemy` | 0 / 低 |
+| `enemy.lowest_phy` | 敵PHY↓ | `--target-enemy` | 0 / 低 |
+| `enemy.highest_int` | 敵INT↑ | `--target-enemy` | 0 / 低 |
+| `enemy.lowest_int` | 敵INT↓ | `--target-enemy` | 0 / 低 |
+| `enemy.highest_hp` | 敵HP↑ | `--target-enemy` | 0 / 低 |
+| `enemy.lowest_hp` | 敵HP↓ | `--target-enemy` | 0 / 中 |
+| `all` | 全体 | `--target-all` | 0 / 低 |
+| `all.random` | 全体ランダム | `--target-all` | 0 / 低 |
+
+**設計根拠**:
+
+1. **「自身」を独立色 (シアン)**: SPEC-006 §5.2 で `self` = caster と同一視するため、味方緑とは概念的に別カテゴリ。`--energy` (#5ab4c4) と同色にして「自分のリソース／状態」というニュアンスを統一
+2. **位置指定 (前/中/後) は 3 文字**: 「味方前」「敵前」で 3-2 文字、視認性と幅両立
+3. **foremost / rearmost も 3 文字維持**: 「味方先」「敵先頭」と「味方尾」「敵最後尾」(敵側のみ 3-4 文字、味方側は 3 文字に圧縮)。**敵側を優先して文字数増やしたのは現状 392 件全てが `enemy.foremost` であり実装初期の視認性優先**。味方側の使用例が増えたら統一する
+4. **stat 系は記号化**: 「味PHY↑」「敵INT↓」など `味/敵 + ステータス略号 (PHY/INT/HP/AGI) + ↑↓` の 5 文字パターン。陣営アイコン (🛡/⚔) 案も検討したが Unicode 絵文字は環境依存 (Windows 11 / iOS / Android で見え方異なる) のため文字ベースに統一
+5. **ランダム表記**: 「敵ランダム」「味方ランダム」で確定 (`?` よりも明示的、4-5 文字、左カラム 60-80px に収まる)
+
+**論点への回答**:
+
+- (1) ラベル文字数: 最長 6 文字 (「敵最後尾」「味方ランダム」「全体ランダム」)。フォントサイズ調整で 60-80px に収める。長すぎる場合は CSS で `font-size: 0.7em` 等で縮小可
+- (2) 色定義: `--accent` (金) との被りを避けるため、全体系を **紫 (#c47ed9)** に。CSS 変数化済み
+- (3) `self` セマンティクス: シアン色で独立。caster ロール併記は不要 (caster 表示エリアが別途存在するため重複表示にならない)
+- (4) 未使用 TargetSpec の deprecate: **ranking 系 (`*.highest_phy` 等) は使用頻度が低そうだが、SPEC-005 §6 から外す判断はまだ早い**。Epic / Legendary 実装後に再評価。とりあえず仕様としては全網羅
+- (5) ランダム系の表記: `敵?` → `敵ランダム` に変更 (明示性優先)。略号が必要なら後日 CSS で省略表示 (`text-overflow: ellipsis`)
+
+**データソース**:
+
+実装側はラベル文字列を [prototype/data/target-labels.json](../../prototype/data/target-labels.json) から読み込む。将来の i18n 対応の素地として JSON 形式で持つ。
 
 ### 7.2 カード券面（バトル外: デッキ / ショップ / クラフト）
 

--- a/prototype/data/target-labels.json
+++ b/prototype/data/target-labels.json
@@ -1,0 +1,39 @@
+{
+  "_meta": {
+    "version": 1,
+    "spec": "SPEC-006 §7.1.1",
+    "description": "TargetSpec 識別子 → カード券面左カラム用日本語ラベル + 色変数のマッピング。SPEC-005 §6 のターゲット仕様語彙を全網羅する。"
+  },
+  "self":               { "label": "自身",         "color": "--target-self"  },
+
+  "ally.front":         { "label": "味方前",       "color": "--target-ally"  },
+  "ally.mid":           { "label": "味方中",       "color": "--target-ally"  },
+  "ally.back":          { "label": "味方後",       "color": "--target-ally"  },
+  "ally.foremost":      { "label": "味方先",       "color": "--target-ally"  },
+  "ally.rearmost":      { "label": "味方尾",       "color": "--target-ally"  },
+  "ally.all":           { "label": "味方全",       "color": "--target-ally"  },
+  "ally.random":        { "label": "味方ランダム", "color": "--target-ally"  },
+  "ally.highest_phy":   { "label": "味PHY↑",      "color": "--target-ally"  },
+  "ally.lowest_phy":    { "label": "味PHY↓",      "color": "--target-ally"  },
+  "ally.highest_int":   { "label": "味INT↑",      "color": "--target-ally"  },
+  "ally.lowest_int":    { "label": "味INT↓",      "color": "--target-ally"  },
+  "ally.highest_hp":    { "label": "味HP↑",       "color": "--target-ally"  },
+  "ally.lowest_hp":     { "label": "味HP↓",       "color": "--target-ally"  },
+
+  "enemy.front":        { "label": "敵前",         "color": "--target-enemy" },
+  "enemy.mid":          { "label": "敵中",         "color": "--target-enemy" },
+  "enemy.back":         { "label": "敵後",         "color": "--target-enemy" },
+  "enemy.foremost":     { "label": "敵先頭",       "color": "--target-enemy" },
+  "enemy.rearmost":     { "label": "敵最後尾",     "color": "--target-enemy" },
+  "enemy.all":          { "label": "敵全",         "color": "--target-enemy" },
+  "enemy.random":       { "label": "敵ランダム",   "color": "--target-enemy" },
+  "enemy.highest_phy":  { "label": "敵PHY↑",      "color": "--target-enemy" },
+  "enemy.lowest_phy":   { "label": "敵PHY↓",      "color": "--target-enemy" },
+  "enemy.highest_int":  { "label": "敵INT↑",      "color": "--target-enemy" },
+  "enemy.lowest_int":   { "label": "敵INT↓",      "color": "--target-enemy" },
+  "enemy.highest_hp":   { "label": "敵HP↑",       "color": "--target-enemy" },
+  "enemy.lowest_hp":    { "label": "敵HP↓",       "color": "--target-enemy" },
+
+  "all":                { "label": "全体",         "color": "--target-all"   },
+  "all.random":         { "label": "全体ランダム", "color": "--target-all"   }
+}


### PR DESCRIPTION
## Summary

3v3 担当エージェントからの依頼（[HANDOFF-REPLY-2-FROM-3V3-AGENT.md](https://github.com/bearko/mycryptotactics/blob/feat/beta-content-extensions/HANDOFF-REPLY-2-FROM-3V3-AGENT.md) §依頼事項）に対応し、SPEC-006 §7 で未確定だった **TargetSpec → 表示ラベル + 色** の対応表を確定。

**Base ブランチ**: `feat/spec-006-card-caster`

## 実態調査

現状の cards.js（PR #51 + #53 マージ後想定 577 件）で使われている TargetSpec の分布:

| TargetSpec | 件数 | 使用率 |
|---|---:|---:|
| `enemy.foremost` | 392 | 67.9% |
| `self` | 185 | 32.1% |
| **その他全て** | 0 | 0% |

SPEC-005 §6 で定義された他の語彙（`ally.*`, `enemy.highest_phy` 等）は現状ゼロ使用。本対応表は **Epic / Legendary 実装後・SPEC-006 caster システム導入後の使用を見込んで全網羅**。

## 設計のポイント

### 色定義（CSS 変数 4 種を新規導入）

```css
:root {
  --target-ally:  #7ed957;  /* 味方系 = 緑 */
  --target-enemy: #e76060;  /* 敵系 = 赤 */
  --target-all:   #c47ed9;  /* 全体系 = 紫 (--accent #c4a35a 金との視認区別) */
  --target-self:  #5ab4c4;  /* 自身 = シアン (--energy と同色) */
}
```

「自身 (self)」を独立色 (シアン) にした理由: SPEC-006 §5.2 で `self` = caster と同一視するため、味方緑とは概念的に別カテゴリ。`--energy` と同色にして「自分のリソース／状態」というニュアンスを統一。

### ラベル文字数

最長 6 文字（「敵最後尾」「味方ランダム」「全体ランダム」）。60-80px 幅カラムに収める。長い場合は CSS の `font-size: 0.7em` 等で縮小。

### 論点 1-5 への回答

| 論点 | 回答 |
|---|---|
| (1) ラベル文字数 | 3-6 文字。Unicode 絵文字 (🛡/⚔) は環境依存のため不採用、文字ベースで統一 |
| (2) 色定義 | CSS 変数化、`--accent` 金との被り回避のため全体系を **紫** |
| (3) `self` セマンティクス | シアンで独立、caster ロール併記は不要（caster 表示エリア別） |
| (4) 未使用 TargetSpec の deprecate | 早計。Epic / Legendary 実装後に再評価。現時点全網羅 |
| (5) ランダム表記 | `敵?` → `敵ランダム` に変更（明示性優先） |

## 主要ラベル抜粋

| TargetSpec | ラベル | 色変数 |
|---|---|---|
| `self` | 自身 | `--target-self` |
| `ally.foremost` | 味方先 | `--target-ally` |
| `ally.lowest_hp` | 味HP↓ | `--target-ally` |
| `enemy.foremost` | 敵先頭 | `--target-enemy` |
| `enemy.all` | 敵全 | `--target-enemy` |
| `enemy.highest_phy` | 敵PHY↑ | `--target-enemy` |
| `all` | 全体 | `--target-all` |

完全な対応表は [SPEC-006 §7.1.1](docs/specs/SPEC-006-card-caster.md#L165) を参照。

## ファイル変更

- [docs/specs/SPEC-006-card-caster.md](docs/specs/SPEC-006-card-caster.md): §7.1.1 を新設、ラベル対応表 (29 エントリ) + 色定義 + 設計根拠 + 論点回答を追加
- [prototype/data/target-labels.json](prototype/data/target-labels.json): 新規データファイル（JS から読み込んで card UI でラベル描画する想定、将来の i18n 対応の素地）

## Test plan

- [x] JSON 構文チェック OK
- [ ] 3v3 担当によるレビュー（色のアクセシビリティ、ラベル長の UI 確認）
- [ ] Phase 4e カード券面 UI 実装時に target-labels.json を読み込んで描画
- [ ] Epic / Legendary カード追加時に未使用 TargetSpec の使用率レビュー → 必要なら deprecate 判断

## 関連

- 上流 PR: [#48 (3v3)](https://github.com/bearko/mycryptotactics/pull/48), feat/spec-006-card-caster (SPEC ベース)
- content 担当 PR: [#50](https://github.com/bearko/mycryptotactics/pull/50) [#51](https://github.com/bearko/mycryptotactics/pull/51) [#52](https://github.com/bearko/mycryptotactics/pull/52) [#53](https://github.com/bearko/mycryptotactics/pull/53)
- 依頼受領: [HANDOFF-REPLY-2-FROM-3V3-AGENT.md](https://github.com/bearko/mycryptotactics/blob/feat/beta-content-extensions/HANDOFF-REPLY-2-FROM-3V3-AGENT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)