### PR TITLE
feat(party-formation): 編成画面 UX 改善 (確定上部 / タップ追加 / D&D / レアフィルタ / レスポンシブ)

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1409,30 +1409,53 @@
       }
     }
 
-    .hs-header { text-align: center; margin-bottom: 1.2rem; }
+    .hs-header { text-align: center; margin-bottom: 0.8rem; }
     .hs-header h2 { margin: 0 0 0.3rem; font-size: 1.2rem; color: var(--accent); }
     .hs-sub { margin: 0; font-size: 0.78rem; color: var(--muted); }
+    /* SPEC-005 Phase 3a + UX 改善: 編成可能ヒーロー一覧をレスポンシブグリッドに */
     .hs-roster {
-      display: flex; flex-wrap: wrap;
-      gap: 0.9rem; justify-content: center; align-items: stretch;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+      gap: 0.6rem;
+      align-items: stretch;
+    }
+    @media (max-width: 480px) {
+      .hs-roster { grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); gap: 0.45rem; }
     }
     .hs-card {
       background: var(--panel);
       border: 2px solid var(--border);
-      border-radius: 14px;
-      width: 200px; max-width: 200px;
+      border-radius: 12px;
       display: flex; flex-direction: column;
-      align-items: center;
+      align-items: stretch;
       overflow: hidden;
+      cursor: pointer;
       transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+      position: relative;
     }
-    .hs-card:hover { border-color: var(--accent); transform: translateY(-3px); box-shadow: 0 8px 24px #000a; }
-    /* SPEC-005 Phase 3a: パーティ編成画面 */
-    .hs-card--in-party { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(253,203,110,0.18); }
-    .hs-in-party-mark { color: var(--accent); font-size: 0.7rem; font-weight: 700; }
+    .hs-card:hover { border-color: var(--accent); transform: translateY(-2px); box-shadow: 0 6px 18px #000a; }
+    .hs-card--in-party { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(196,163,90,0.25); }
+    .hs-card--in-party::after {
+      content: "✓ 編成中";
+      position: absolute; top: 4px; right: 4px;
+      font-size: 0.6rem; font-weight: 800;
+      color: var(--accent);
+      background: rgba(20,16,32,0.85);
+      padding: 2px 6px; border-radius: 8px;
+      border: 1px solid var(--accent);
+    }
+    /* レアリティ枠色 (cards.js の RARITY 色を流用) */
+    .hs-card[data-rarity="legendary"] { border-color: #D63031; }
+    .hs-card[data-rarity="epic"]      { border-color: #E17055; }
+    .hs-card[data-rarity="rare"]      { border-color: #FDCB6E; }
+    .hs-card[data-rarity="uncommon"]  { border-color: #00B894; }
+    .hs-card[data-rarity="common"]    { border-color: #0984E3; }
+    .hs-card.hs-card--in-party { border-color: var(--accent); }
+
+    /* ── 上部: 現在のパーティ + 確定ボタン ────────────────── */
     .ps-current {
       display: flex; gap: 0.55rem; justify-content: center; flex-wrap: wrap;
-      margin: 0.6rem auto 1.1rem;
+      margin: 0.6rem auto 0.6rem;
       padding: 0.55rem 0.5rem;
       background: #0e0a18; border: 1px solid var(--border);
       border-radius: 10px; max-width: 520px;
@@ -1443,9 +1466,17 @@
       border-radius: 8px; padding: 0.45rem 0.4rem 0.55rem;
       display: flex; flex-direction: column; align-items: center; gap: 0.25rem;
       position: relative; min-height: 110px;
+      transition: border-color 0.15s, background 0.15s, transform 0.15s;
+    }
+    .ps-slot[draggable="true"] { cursor: grab; }
+    .ps-slot[draggable="true"]:active { cursor: grabbing; }
+    .ps-slot.ps-slot--dragging { opacity: 0.4; }
+    .ps-slot.ps-slot--drop-target {
+      border-color: var(--accent); border-style: solid;
+      background: #1f1830; transform: scale(1.04);
     }
     .ps-slot-pos { font-size: 0.65rem; color: var(--accent); font-weight: 800; letter-spacing: 0.06em; }
-    .ps-slot-img { width: 60px; height: 60px; object-fit: contain; image-rendering: pixelated; }
+    .ps-slot-img { width: 60px; height: 60px; object-fit: contain; image-rendering: pixelated; pointer-events: none; }
     .ps-slot-name { font-size: 0.7rem; font-weight: 700; color: var(--text); line-height: 1.2; text-align: center; }
     .ps-slot-empty { font-size: 0.7rem; color: var(--muted); padding: 1.4rem 0 0; }
     .ps-slot-remove {
@@ -1456,51 +1487,82 @@
     }
     .ps-confirm-row {
       display: flex; justify-content: center;
-      margin: 1.2rem 0 0.6rem;
+      margin: 0.4rem 0 0.8rem;
     }
     .ps-confirm-btn {
       font-size: 0.95rem; padding: 0.6rem 1.4rem;
     }
+
+    /* ── レアリティフィルタ ───────────────────────── */
+    .hs-rarity-filter {
+      display: flex; gap: 0.4rem; flex-wrap: wrap;
+      justify-content: center; align-items: center;
+      margin: 0.4rem 0 0.7rem;
+    }
+    .hs-rarity-filter-label {
+      font-size: 0.7rem; color: var(--muted); font-weight: 700;
+      margin-right: 0.3rem;
+    }
+    .hs-rarity-pill {
+      display: inline-flex; align-items: center; justify-content: center;
+      min-width: 32px; height: 32px;
+      border-radius: 999px;
+      font-size: 0.85rem; font-weight: 800;
+      color: #fff; cursor: pointer; user-select: none;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+      transition: transform 0.1s, opacity 0.15s, outline 0.1s;
+      border: 2px solid transparent;
+      opacity: 0.5;
+    }
+    .hs-rarity-pill:hover { transform: scale(1.08); opacity: 0.8; }
+    .hs-rarity-pill[data-active="true"] { opacity: 1; outline: 2px solid var(--text); outline-offset: 2px; }
+    .hs-rarity-pill[data-rarity="legendary"] { background: #D63031; }
+    .hs-rarity-pill[data-rarity="epic"]      { background: #E17055; }
+    .hs-rarity-pill[data-rarity="rare"]      { background: #FDCB6E; color: #2c1810; }
+    .hs-rarity-pill[data-rarity="uncommon"]  { background: #00B894; }
+    .hs-rarity-pill[data-rarity="common"]    { background: #0984E3; }
+    .hs-rarity-pill[data-rarity="normal"]    { background: #6c6c80; }
+    .hs-rarity-pill[data-rarity="all"]       { background: #2a2438; color: var(--text); border-color: var(--border); }
+    .hs-rarity-pill[data-rarity="all"][data-active="true"] { border-color: var(--accent); }
+
+    /* ── 編成可能ヒーローカード ──────────────────── */
     .hs-hero-img {
-      width: 100%; height: 160px;
+      width: 100%; height: 110px;
       object-fit: contain; image-rendering: pixelated;
       background: #0f0c18;
       display: block;
+      pointer-events: none;
     }
     .hs-hero-body {
-      padding: 0.65rem 0.6rem 0.75rem;
-      display: flex; flex-direction: column; gap: 0.45rem;
+      padding: 0.5rem 0.5rem 0.55rem;
+      display: flex; flex-direction: column; gap: 0.35rem;
       width: 100%;
     }
     .hs-hero-name {
-      font-size: 0.95rem; font-weight: 800;
+      font-size: 0.85rem; font-weight: 800;
       color: var(--accent); text-align: center;
+      line-height: 1.2;
     }
     .hs-hero-stats {
-      display: flex; flex-wrap: wrap; gap: 0.3rem;
-      justify-content: center; font-size: 0.7rem; color: var(--muted);
+      display: flex; flex-wrap: wrap; gap: 0.2rem;
+      justify-content: center; font-size: 0.62rem; color: var(--muted);
     }
     .hs-hero-stats span {
       background: #15121c;
       border: 1px solid var(--border);
-      border-radius: 4px; padding: 0.15rem 0.4rem;
+      border-radius: 4px; padding: 0.1rem 0.3rem;
     }
     .hs-passive {
-      font-size: 0.68rem; color: #a0c8d8; line-height: 1.45;
+      font-size: 0.62rem; color: #a0c8d8; line-height: 1.35;
       background: rgba(0,120,160,0.12);
       border-left: 2px solid #5ab4c4;
-      padding: 0.3rem 0.4rem;
+      padding: 0.25rem 0.35rem;
       border-radius: 0 6px 6px 0;
     }
     .hs-passive-name {
       display: block;
-      font-size: 0.75rem; font-weight: 800;
-      color: #7de8f8; margin-bottom: 0.2rem;
-    }
-    .hs-select-btn {
-      width: 100%; font-size: 0.78rem;
-      padding: 0.45rem; border-radius: 8px;
-      margin-top: auto;
+      font-size: 0.68rem; font-weight: 800;
+      color: #7de8f8; margin-bottom: 0.15rem;
     }
 
     /* ── Craft Screen ─────────────────────────────────────────────── */

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -4179,6 +4179,19 @@ function renderEnemySubUnits() {
 let pendingPartyHeroIds = []; // ユーザーが選択中のヒーロー id 配列（最大 3）
 const PARTY_MAX = 3;
 
+// レアリティフィルタの選択状態 ('all' or 個別 rarity 名 1 種)。リロードまで保持。
+let pendingRarityFilter = "all";
+
+const RARITY_FILTER_PILLS = [
+  { key: "all",       letter: "全",  label: "すべて" },
+  { key: "legendary", letter: "L",  label: "レジェンド" },
+  { key: "epic",      letter: "E",  label: "エピック" },
+  { key: "rare",      letter: "R",  label: "レア" },
+  { key: "uncommon",  letter: "U",  label: "アンコモン" },
+  { key: "common",    letter: "C",  label: "コモン" },
+  { key: "normal",    letter: "N",  label: "ノーマル" },
+];
+
 function renderHeroSelect() {
   // SPEC-005 Phase 3: ヒーロー選択 → パーティ選択 (1〜3 体)
   // 関数名は既存呼び出しとの互換のため維持。中身はパーティ編成。
@@ -4193,7 +4206,7 @@ function renderHeroSelect() {
   const renderInner = () => {
     let html = '<div class="hs-header">';
     html += '<h2>パーティを編成</h2>';
-    html += '<p class="hs-sub">最大 3 体まで選べます。先に選んだヒーローほど前衛 (画面中央寄り) に配置されます</p>';
+    html += '<p class="hs-sub">最大 3 体まで選べます。先に選んだヒーローほど前衛 (画面中央寄り) に配置 / 下のスロットを<strong>ドラッグ＆ドロップ</strong>で並び替え可能</p>';
     html += '</div>';
 
     // 現在のパーティ表示 (3 スロット)
@@ -4202,7 +4215,8 @@ function renderHeroSelect() {
       const hid = pendingPartyHeroIds[pos];
       const h = hid ? HERO_ROSTER.find(x => x.heroId === hid) : null;
       const posLabel = ["前衛", "中衛", "後衛"][pos];
-      html += `<div class="ps-slot ps-slot--${pos}" data-pos="${pos}">`;
+      const dragAttr = h ? 'draggable="true"' : '';
+      html += `<div class="ps-slot ps-slot--${pos}" data-pos="${pos}" ${dragAttr}>`;
       html += `<div class="ps-slot-pos">${posLabel}</div>`;
       if (h) {
         html += `<img class="ps-slot-img" src="${h.img()}" alt="${h.nameJa}" />`;
@@ -4215,37 +4229,7 @@ function renderHeroSelect() {
     }
     html += '</div>';
 
-    // 選択可能なヒーロー一覧
-    html += '<div class="hs-header" style="margin-top:1.2rem;"><h3 style="font-size:1rem;color:var(--accent);margin:0;">編成可能なヒーロー</h3></div>';
-    html += '<div class="hs-roster">';
-    HERO_ROSTER.forEach((hero) => {
-      const inParty = pendingPartyHeroIds.includes(hero.heroId);
-      const partyFull = pendingPartyHeroIds.length >= PARTY_MAX;
-      const cls = ['hs-card'];
-      if (inParty) cls.push('hs-card--in-party');
-      html += `<div class="${cls.join(' ')}" data-hid="${hero.heroId}" role="button" tabindex="0">`;
-      html += `<img class="hs-hero-img" src="${hero.img()}" alt="${hero.nameJa}" />`;
-      html += `<div class="hs-hero-body">`;
-      html += `<div class="hs-hero-name">${hero.nameJa}${inParty ? ' <span class="hs-in-party-mark">(編成中)</span>' : ''}</div>`;
-      html += `<div class="hs-hero-stats">`;
-      html += `<span>HP ${hero.hpMax}</span>`;
-      html += `<span>PHY ${hero.basePhy}</span>`;
-      html += `<span>INT ${hero.baseInt}</span>`;
-      html += `<span>AGI ${hero.baseAgi}</span>`;
-      html += `</div>`;
-      html += `<div class="hs-passive"><span class="hs-passive-name">【${hero.passiveName || '—'}】</span>${hero.passiveDesc}</div>`;
-      if (inParty) {
-        html += `<button class="hs-select-btn action" data-action="remove" data-hid="${hero.heroId}">パーティから外す</button>`;
-      } else if (partyFull) {
-        html += `<button class="hs-select-btn action" disabled>パーティ満員</button>`;
-      } else {
-        html += `<button class="hs-select-btn action" data-action="add" data-hid="${hero.heroId}">パーティに加える</button>`;
-      }
-      html += `</div></div>`;
-    });
-    html += '</div>';
-
-    // 確定ボタン
+    // 確定ボタン (画面上部に移動)
     html += '<div class="ps-confirm-row">';
     const partyCount = pendingPartyHeroIds.length;
     const canStart = partyCount >= 1;
@@ -4253,27 +4237,74 @@ function renderHeroSelect() {
     html += `編成を確定（${partyCount}/${PARTY_MAX} 体）→ 出撃</button>`;
     html += '</div>';
 
+    // 選択可能なヒーロー一覧
+    html += '<div class="hs-header" style="margin-top:1.0rem;"><h3 style="font-size:1rem;color:var(--accent);margin:0;">編成可能なヒーロー</h3>';
+    html += '<p class="hs-sub" style="margin-top:0.25rem;">カードをタップで追加 / もう一度タップで外す</p>';
+    html += '</div>';
+
+    // レアリティフィルタ
+    html += '<div class="hs-rarity-filter" role="group" aria-label="レアリティで絞り込み">';
+    html += '<span class="hs-rarity-filter-label">レアリティ</span>';
+    for (const p of RARITY_FILTER_PILLS) {
+      const active = (pendingRarityFilter === p.key);
+      html += `<button class="hs-rarity-pill" data-rarity="${p.key}" data-active="${active}" type="button" title="${p.label}">${p.letter}</button>`;
+    }
+    html += '</div>';
+
+    // ヒーロー一覧 (フィルタ適用)
+    html += '<div class="hs-roster">';
+    const filtered = HERO_ROSTER.filter(hero => {
+      if (pendingRarityFilter === "all") return true;
+      const r = hero.rarity || "normal";
+      return r === pendingRarityFilter;
+    });
+    if (filtered.length === 0) {
+      html += `<p style="grid-column:1/-1;text-align:center;color:var(--muted);font-size:0.8rem;padding:1rem;">該当するヒーローがいません</p>`;
+    }
+    filtered.forEach((hero) => {
+      const inParty = pendingPartyHeroIds.includes(hero.heroId);
+      const cls = ['hs-card'];
+      if (inParty) cls.push('hs-card--in-party');
+      const r = hero.rarity || "normal";
+      html += `<div class="${cls.join(' ')}" data-hid="${hero.heroId}" data-rarity="${r}" role="button" tabindex="0" aria-pressed="${inParty}">`;
+      html += `<img class="hs-hero-img" src="${hero.img()}" alt="${hero.nameJa}" />`;
+      html += `<div class="hs-hero-body">`;
+      html += `<div class="hs-hero-name">${hero.nameJa}</div>`;
+      html += `<div class="hs-hero-stats">`;
+      html += `<span>HP ${hero.hpMax}</span>`;
+      html += `<span>PHY ${hero.basePhy}</span>`;
+      html += `<span>INT ${hero.baseInt}</span>`;
+      html += `<span>AGI ${hero.baseAgi}</span>`;
+      html += `</div>`;
+      html += `<div class="hs-passive"><span class="hs-passive-name">【${hero.passiveName || '—'}】</span>${hero.passiveDesc}</div>`;
+      html += `</div></div>`;
+    });
+    html += '</div>';
+
     el.innerHTML = html;
 
-    // イベント
-    el.querySelectorAll('[data-action="add"]').forEach(btn => {
-      btn.addEventListener('click', (ev) => {
+    // ── イベント ──────────────────────────────────
+    // (1) ヒーローカード click でトグル追加/削除
+    el.querySelectorAll('.hs-card').forEach(card => {
+      const handle = (ev) => {
         ev.stopPropagation();
-        const hid = parseInt(btn.dataset.hid, 10);
-        if (pendingPartyHeroIds.length < PARTY_MAX && !pendingPartyHeroIds.includes(hid)) {
+        const hid = parseInt(card.dataset.hid, 10);
+        const inParty = pendingPartyHeroIds.includes(hid);
+        if (inParty) {
+          pendingPartyHeroIds = pendingPartyHeroIds.filter(id => id !== hid);
+        } else {
+          if (pendingPartyHeroIds.length >= PARTY_MAX) return; // 満員時は追加不可
           pendingPartyHeroIds.push(hid);
-          renderInner();
         }
-      });
-    });
-    el.querySelectorAll('[data-action="remove"]').forEach(btn => {
-      btn.addEventListener('click', (ev) => {
-        ev.stopPropagation();
-        const hid = parseInt(btn.dataset.hid, 10);
-        pendingPartyHeroIds = pendingPartyHeroIds.filter(id => id !== hid);
         renderInner();
+      };
+      card.addEventListener('click', handle);
+      card.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); handle(ev); }
       });
     });
+
+    // (2) スロット内 ✕ ボタンで外す
     el.querySelectorAll('[data-remove-pos]').forEach(btn => {
       btn.addEventListener('click', (ev) => {
         ev.stopPropagation();
@@ -4282,6 +4313,8 @@ function renderHeroSelect() {
         renderInner();
       });
     });
+
+    // (3) 確定ボタン
     el.querySelector('.ps-confirm-btn')?.addEventListener('click', () => {
       if (pendingPartyHeroIds.length < 1) return;
       // パーティ確定 → setLeader は前衛 (party[0]) を従来通り反映
@@ -4290,6 +4323,69 @@ function renderHeroSelect() {
       pendingPartyConfirmed = pendingPartyHeroIds.slice(); // 後で startRunFromChapter / ensureRunState で読む
       showView("nodeSelect");
       renderNodeSelect();
+    });
+
+    // (4) レアリティフィルタピル
+    el.querySelectorAll('.hs-rarity-pill').forEach(pill => {
+      pill.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        const key = pill.dataset.rarity;
+        // 同じピル再タップで "all" に戻す。それ以外なら選択切替
+        if (pendingRarityFilter === key && key !== "all") {
+          pendingRarityFilter = "all";
+        } else {
+          pendingRarityFilter = key;
+        }
+        renderInner();
+      });
+    });
+
+    // (5) スロット間の D&D 並び替え
+    let dragSourcePos = null;
+    el.querySelectorAll('.ps-slot[draggable="true"]').forEach(slot => {
+      slot.addEventListener('dragstart', (ev) => {
+        dragSourcePos = parseInt(slot.dataset.pos, 10);
+        slot.classList.add('ps-slot--dragging');
+        try { ev.dataTransfer.setData('text/plain', String(dragSourcePos)); } catch {}
+        ev.dataTransfer.effectAllowed = 'move';
+      });
+      slot.addEventListener('dragend', () => {
+        slot.classList.remove('ps-slot--dragging');
+        el.querySelectorAll('.ps-slot--drop-target').forEach(s => s.classList.remove('ps-slot--drop-target'));
+        dragSourcePos = null;
+      });
+    });
+    el.querySelectorAll('.ps-slot').forEach(slot => {
+      slot.addEventListener('dragover', (ev) => {
+        if (dragSourcePos === null) return;
+        const targetPos = parseInt(slot.dataset.pos, 10);
+        if (targetPos === dragSourcePos) return;
+        ev.preventDefault();
+        ev.dataTransfer.dropEffect = 'move';
+        slot.classList.add('ps-slot--drop-target');
+      });
+      slot.addEventListener('dragleave', () => {
+        slot.classList.remove('ps-slot--drop-target');
+      });
+      slot.addEventListener('drop', (ev) => {
+        ev.preventDefault();
+        slot.classList.remove('ps-slot--drop-target');
+        const targetPos = parseInt(slot.dataset.pos, 10);
+        const srcPos = dragSourcePos !== null
+          ? dragSourcePos
+          : parseInt(ev.dataTransfer.getData('text/plain') || '-1', 10);
+        if (!Number.isFinite(srcPos) || srcPos < 0 || srcPos === targetPos) return;
+        // pendingPartyHeroIds[srcPos] と [targetPos] を入れ替え (ドロップ先が空なら移動)
+        const arr = pendingPartyHeroIds.slice();
+        // 配列を 3 要素 (空は undefined) に正規化
+        const slots = [arr[0], arr[1], arr[2]];
+        const tmp = slots[srcPos];
+        slots[srcPos] = slots[targetPos];
+        slots[targetPos] = tmp;
+        // undefined を除去して詰める (空スロットを末尾に寄せる)
+        pendingPartyHeroIds = slots.filter(x => x !== undefined && x !== null);
+        renderInner();
+      });
     });
   };
 


### PR DESCRIPTION
## Summary
ヒーロー数が 63 → 113 (PR #55 後) と急増している中で、編成画面のスクロール量・列数・操作ステップ数が増えすぎる問題を解消する 6 件の UX 改善。

- **編成確定ボタンを画面上部に**: パーティ表示直下・編成可能ヒーロー一覧の上に配置、最下部までスクロール不要
- **カードタップで追加/削除をトグル**: 旧「パーティに加える」ボタン廃止、編成中バッジ表示、a11y 対応 (Enter/Space, aria-pressed)
- **前衛/中衛/後衛の D&D 並び替え**: HTML5 native drag-and-drop で 2 スロット間 swap、空スロットへ移動も対応、ドロップ先を金枠ハイライト、説明文に追記
- **レアリティフィルタ (L/E/R/U/C/N + 全て)**: 既存 deck pill のカラーパレットを流用、単一選択モード
- **PC: レスポンシブ列数**: `repeat(auto-fill, minmax(150px, 1fr))` で画面幅次第で 4-8 列
- **スマホ: 最低 2-3 列**: 480px 以下で `minmax(110px, 1fr)`、カード本体も縮小 (portrait 110px / フォント全体 -15%)

カード枠色も `data-rarity` 属性でレアリティ準拠に。編成中は accent 金色で上書き。

## Test plan
- [ ] スマホサイズ (~375px) で 2-3 列並ぶ
- [ ] PC サイズで 4-8 列並ぶ
- [ ] カードタップで追加/削除がトグルする
- [ ] パーティ満員 (3 体) でカードタップしても追加されない
- [ ] 前衛 ⇔ 中衛 をドラッグで入れ替えられる
- [ ] レアリティピル「U」で Uncommon 53 体だけ表示される
- [ ] 「N」(ノーマル) は該当ヒーロー無しメッセージ表示
- [ ] 編成確定 → 出撃で次画面へ遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)