### PR TITLE
feat(regulation): Absolute レギュレーション追加（SPEC-007）

### DIFF
--- a/docs/specs/SPEC-007-ranking-and-absolute.md
+++ b/docs/specs/SPEC-007-ranking-and-absolute.md
@@ -1,0 +1,286 @@
+# SPEC-007: ランキング機能 + Absolute レギュレーション
+
+## 1. 概要
+
+クリア時のランキングシステムと、ユーザー設定可能な Absolute レギュレーションを並行実装する。両機能は連携：Absolute の倍率設定がランキングのスコア乗数になる。
+
+## 2. 動機
+
+- **ランキング**: クリア後の競争要素・コミュニティ感醸成。耐久プレイ（生存重視）と速攻プレイ（スコア重視）でゲーム性に幅
+- **Absolute**: 既存 5 段階レギュレーション (Common〜Red) を超えた自由度。上位プレイヤーの設定倍率を観測することで難易度バランス調整の指標を得る
+
+## 3. 用語
+
+| 用語 | 意味 |
+|---|---|
+| Absolute レギュレーション | ユーザーが HP/ダメージ倍率 4 種を任意設定する第 6 のレギュレーション |
+| 倍率 4 種 | 敵 HP / 敵ダメ / 自 HP / 自ダメ (各 0.1x〜5.0x) |
+| ベーススコア | レギュレーション乗数を掛ける前のスコア値 |
+| ファイナルスコア | ベース × レギュレーション乗数の最終値（ランキング登録値）|
+
+## 4. 機能 A: Absolute レギュレーション
+
+### 4.1 データモデル
+
+`prototype/js/regulations.js` に追加:
+
+```js
+{
+  id: "absolute",
+  nameJa: "Absolute",
+  iconUrl: CUP_BASE + "1305.png",  // 仮、別途調達
+  color: "#a855f7",                 // 紫
+  descShort: "ユーザー設定 (敵 HP / 敵ダメ / 自 HP / 自ダメ)",
+  effects: {
+    hpFactor: 1.0,    // = enemyHpMult, runtime に上書きされる
+    atkFactor: 1.0,   // = enemyDmgMult
+    guardPerTurn: 0,
+    bleedOnAttack: 0,
+    isAbsolute: true, // フラグ
+  },
+}
+```
+
+### 4.2 Absolute 設定の保存
+
+新ファイル `prototype/js/absolute-config.js`:
+
+```js
+const LS_KEY = "mct.absoluteConfig";
+const DEFAULT_CONFIG = {
+  enemyHpMult: 1.0,   // 敵 HP 倍率 (0.1〜5.0)
+  enemyDmgMult: 1.0,  // 敵ダメ倍率
+  playerHpMult: 1.0,  // 自 HP 倍率
+  playerDmgMult: 1.0, // 自ダメ倍率
+};
+
+export function loadAbsoluteConfig() { /* ... */ }
+export function saveAbsoluteConfig(cfg) { /* ... */ }
+export function getAbsoluteScoreMult(cfg) {
+  // 高難易度ほどスコア倍率も高い
+  return (cfg.enemyHpMult * cfg.enemyDmgMult) / (cfg.playerHpMult * cfg.playerDmgMult);
+}
+```
+
+### 4.3 戦闘への適用
+
+`startCombatFromMapNode` で:
+
+```js
+const reg = getCurrentRegulation();
+const abs = reg.effects.isAbsolute ? loadAbsoluteConfig() : null;
+const enemyHpMult = abs?.enemyHpMult ?? reg.effects.hpFactor;
+const enemyDmgMult = abs?.enemyDmgMult ?? reg.effects.atkFactor;
+const playerHpMult = abs?.playerHpMult ?? 1.0;
+const playerDmgMult = abs?.playerDmgMult ?? 1.0;
+
+// enemy stats: × enemyHpMult / × enemyDmgMult
+// player stats: × playerHpMult (HP), 攻撃時に × playerDmgMult
+```
+
+`playerHpMult` は新規パラメータなので、`runState.playerHpMax` 初期化時に適用。
+`playerDmgMult` は `dealPhySkillToEnemy` / `dealIntSkillToEnemy` 内でダメ計算に乗算（要追加）。
+
+### 4.4 設定 UI
+
+レギュレーション選択画面 (`#regulationSelectView`) で「Absolute」選択時に **設定モーダル** を開く:
+
+```
+┌─ Absolute レギュレーション設定 ─┐
+│ 敵 HP 倍率:   [== slider ==] 1.5x │
+│ 敵ダメ倍率:   [==== slider ====] 2.0x │
+│ 自 HP 倍率:   [== slider ==] 0.8x │
+│ 自ダメ倍率:   [==== slider ====] 1.0x │
+│                                    │
+│ スコア倍率: 3.75x                  │
+│ [キャンセル]  [この設定で開始]     │
+└───────────────────────────────────┘
+```
+
+slider 範囲: 0.1〜5.0 (0.1 刻み)。スコア倍率 = `(enemyHpMult × enemyDmgMult) / (playerHpMult × playerDmgMult)` をリアルタイム計算表示。
+
+## 5. 機能 B: ランキング機能
+
+### 5.1 スコア計算
+
+新ファイル `prototype/js/scoring.js`:
+
+```js
+const RARITY_VALUES = { legendary: 1, epic: 2, rare: 3, uncommon: 4, common: 5 };
+
+export function computeBaseScore({ turns, deckSize, llExtCount, partyHeroes }) {
+  const turnBonus = Math.max(0, 500 - turns) * 30;
+  const deckBonus = deckSize * 50;
+  const llBonus = llExtCount * 3000;
+  const rarityBonus = partyHeroes.reduce((sum, h) =>
+    sum + (RARITY_VALUES[h.rarity] || 3) * 500, 0);
+  return turnBonus + deckBonus + llBonus + rarityBonus;
+}
+
+export function computeFinalScore({ baseScore, regulation, absoluteConfig }) {
+  const regMult = REGULATION_SCORE_MULTS[regulation.id] || 1.0;
+  const absMult = regulation.id === "absolute"
+    ? getAbsoluteScoreMult(absoluteConfig)
+    : 1.0;
+  return Math.round(baseScore * regMult * absMult);
+}
+
+const REGULATION_SCORE_MULTS = {
+  common: 1.0,
+  egg: 1.2,
+  baby: 1.5,
+  blue: 2.0,
+  red: 3.0,
+  absolute: 1.0,  // absMult が別途掛かる
+};
+```
+
+### 5.2 サンプル計算
+
+| シナリオ | 計算 | スコア |
+|---|---|---:|
+| 100 turn / 20 deck / 0 LL / 3 common / Common reg | 12000+1000+0+7500 = 20500 × 1.0 | 20,500 |
+| 100 turn / 20 deck / 2 LL / 3 common / Red reg | (12000+1000+6000+7500) × 3.0 | 79,500 |
+| 100 turn / 20 deck / 2 LL / 3 legendary / Common reg | (12000+1000+6000+1500) × 1.0 | 20,500 |
+| 100 turn / 20 deck / 2 LL / 3 common / Absolute (敵×2.0倍, 自×0.5倍) | 26500 × 8.0 | 212,000 |
+
+→ 速攻 + 大デッキ + LL 活用 + 低レア縛り + 高難易度 でスコア最大化
+
+### 5.3 ランキング送信フロー
+
+クリア時:
+1. `runState` から turn / deck / LL / party 抽出
+2. スコア計算
+3. **モーダル表示**: 「○○、ランキングに登録しますか？」
+   - プレイヤー名表示（localStorage）/ 編集可能
+   - 「登録する」「やめる」
+4. 登録時: GAS web app に POST
+5. 完了通知
+
+### 5.4 ランキング表示画面
+
+新規ビュー `#rankingView`:
+- 全体トップ 50
+- レギュレーション別フィルタ (Common / Egg / ... / Red / Absolute)
+- 各エントリ: ランク / プレイヤー名 / スコア / レギュレーション / 内訳ハイライト (turn / deck / LL / rarity)
+- Absolute エントリは **倍率 4 種を併記**
+
+メイン画面から `[ランキング]` ボタンでアクセス。
+
+### 5.5 GAS 仕様
+
+`docs/setup-google-apps-script.md` に手順記載。要点:
+
+#### Spreadsheet 列
+| timestamp | playerName | score | regulation | turns | deckSize | llExt | heroIds | absoluteHpE | absoluteDmgE | absoluteHpP | absoluteDmgP | version |
+
+#### GAS web app コード（雛形）
+```js
+function doPost(e) {
+  const data = JSON.parse(e.postData.contents);
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("ranking");
+  sheet.appendRow([
+    new Date(),
+    data.playerName,
+    data.score,
+    data.regulation,
+    data.turns,
+    data.deckSize,
+    data.llExt,
+    data.heroIds.join(","),
+    data.absoluteConfig?.enemyHpMult || "",
+    data.absoluteConfig?.enemyDmgMult || "",
+    data.absoluteConfig?.playerHpMult || "",
+    data.absoluteConfig?.playerDmgMult || "",
+    data.version,
+  ]);
+  return ContentService.createTextOutput(JSON.stringify({ ok: true }))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+function doGet(e) {
+  const filter = e.parameter.regulation;  // optional
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("ranking");
+  let rows = sheet.getDataRange().getValues().slice(1);  // skip header
+  if (filter) rows = rows.filter(r => r[3] === filter);
+  rows.sort((a, b) => b[2] - a[2]);  // by score desc
+  const top = rows.slice(0, 50).map(r => ({
+    timestamp: r[0],
+    playerName: r[1],
+    score: r[2],
+    regulation: r[3],
+    turns: r[4],
+    deckSize: r[5],
+    llExt: r[6],
+    heroIds: r[7],
+    absolute: r[8] ? { enemyHpMult: r[8], enemyDmgMult: r[9], playerHpMult: r[10], playerDmgMult: r[11] } : null,
+  }));
+  return ContentService.createTextOutput(JSON.stringify({ ok: true, ranking: top }))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+```
+
+#### デプロイ
+- 「ウェブアプリとしてデプロイ」 → 「全員（匿名含む）」アクセス可
+- URL を `prototype/js/ranking-client.js` の定数に書き込み
+
+### 5.6 不正対策
+
+クライアント送信値をそのまま信頼。CORS 設定だけ適切に。「カジュアルランキング」として位置付け、将来必要なら GAS 側で異常値フィルタ追加（例：score 上限 10,000,000 / turn 下限 10）。
+
+## 6. データモデルへの追加
+
+### 6.1 runState 拡張
+
+```js
+runState = {
+  // 既存...
+  totalTurns: 0,            // ★新規 — クリア時のターン数積算
+};
+```
+
+各戦闘終了時に `runState.totalTurns += combat.turn` で加算。
+
+### 6.2 localStorage キー追加
+
+| キー | 内容 |
+|---|---|
+| `mct.absoluteConfig` | Absolute 倍率 4 種 |
+| `mct.playerName` | ランキング送信用名 |
+| `mct.rankingApiUrl` | GAS web app URL（ユーザー設定可、空なら送信無効）|
+
+## 7. 実装順序
+
+1. **PR A**: Absolute レギュレーション
+   - regulations.js 拡張
+   - absolute-config.js 新設
+   - 戦闘への倍率適用
+   - 設定モーダル UI
+2. **PR B**: ランキング機能 (PR A 依存)
+   - scoring.js 新設
+   - turn 集計 (runState)
+   - ranking-client.js 新設
+   - 送信モーダル / 表示画面
+   - GAS セットアップ手順書
+
+両 PR は **3v3 担当の Phase 4 進行と無干渉** (新規ファイル中心 + 既存への INSERT のみ)。Phase 4f (per-hero state) 進行時に runState shape が変わる可能性あり、その場合 rebase で対応。
+
+## 8. UI 仕様詳細（Phase 4 整合）
+
+3v3 担当の Phase 4e でカード券面 UI が刷新済み。新規 UI は同じ視覚言語で:
+- 色: `--target-ally` (緑) を「自分」、`--target-enemy` (赤) を「敵」のラベルに使用
+- フォント: 既存の `var(--accent)` ベース
+- モーダル: 既存の cutin / help overlay と同じ z-index 階層
+
+## 9. 非目標
+
+- ✗ サーバー側のスコア検証（クライアント信頼）
+- ✗ リアルタイムランキング更新（手動リロード）
+- ✗ 複数アカウント対応（localStorage のみ）
+- ✗ プレイ動画/リプレイ
+- ✗ シーズン制（時系列でテーブル分割しない）
+
+## 10. 関連 SPEC
+
+- SPEC-005 §6: ターゲット仕様（Absolute 倍率は target.\* に直接影響しない、計算層で適用）
+- SPEC-006 §18: Phase 4j で passive trigger DSL 化される際、Absolute 倍率は trigger 解決には影響なし

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1313,6 +1313,29 @@
       padding: 0.75rem;
     }
     #helpOverlay.hidden { display: none; }
+
+    /* SPEC-007: Absolute 設定モーダル */
+    #absoluteConfigOverlay {
+      position: fixed; inset: 0; background: #000c; z-index: 210;
+      display: flex; align-items: center; justify-content: center; padding: 0.75rem;
+    }
+    #absoluteConfigOverlay.hidden { display: none; }
+    .abs-dialog {
+      background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+      width: 100%; max-width: 460px; padding: 1rem 1.25rem; display: flex; flex-direction: column; gap: 0.75rem;
+    }
+    .abs-title { color: #a855f7; font-size: 1.1rem; font-weight: 600; margin: 0 0 0.25rem; }
+    .abs-row { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+    .abs-row label { flex: 0 0 8em; font-size: 0.9rem; }
+    .abs-row input[type="range"] { flex: 1 1 auto; min-width: 100px; }
+    .abs-row .abs-val { flex: 0 0 4em; text-align: right; font-variant-numeric: tabular-nums; color: var(--accent); }
+    .abs-score-row {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.5rem 0.75rem; background: #2a2438; border-radius: 8px; margin-top: 0.25rem;
+    }
+    .abs-score-row .abs-score-label { color: var(--text); font-size: 0.95rem; }
+    .abs-score-row .abs-score-mult { color: #a855f7; font-size: 1.2rem; font-weight: 600; }
+    .abs-buttons { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 0.5rem; }
     .help-dialog {
       background: var(--panel);
       border: 1px solid var(--border);
@@ -2653,6 +2676,45 @@
       へ
     </span>
   </footer>
+
+  <!-- SPEC-007: Absolute レギュレーション設定モーダル -->
+  <div id="absoluteConfigOverlay" class="hidden" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="absTitle">
+    <div class="abs-dialog">
+      <h2 id="absTitle" class="abs-title">Absolute レギュレーション設定</h2>
+      <p style="font-size:0.85rem;color:var(--muted);margin:0;">各倍率は 0.1〜5.0、0.1 刻み。スライダーを動かすとスコア倍率が再計算されます。</p>
+
+      <div class="abs-row">
+        <label for="absSlider-enemyHpMult">敵 HP 倍率</label>
+        <input id="absSlider-enemyHpMult" type="range" min="0.1" max="5.0" step="0.1" value="1.0" data-abs-key="enemyHpMult" />
+        <span class="abs-val" data-abs-val="enemyHpMult">1.0x</span>
+      </div>
+      <div class="abs-row">
+        <label for="absSlider-enemyDmgMult">敵ダメ倍率</label>
+        <input id="absSlider-enemyDmgMult" type="range" min="0.1" max="5.0" step="0.1" value="1.0" data-abs-key="enemyDmgMult" />
+        <span class="abs-val" data-abs-val="enemyDmgMult">1.0x</span>
+      </div>
+      <div class="abs-row">
+        <label for="absSlider-playerHpMult">自 HP 倍率</label>
+        <input id="absSlider-playerHpMult" type="range" min="0.1" max="5.0" step="0.1" value="1.0" data-abs-key="playerHpMult" />
+        <span class="abs-val" data-abs-val="playerHpMult">1.0x</span>
+      </div>
+      <div class="abs-row">
+        <label for="absSlider-playerDmgMult">自ダメ倍率</label>
+        <input id="absSlider-playerDmgMult" type="range" min="0.1" max="5.0" step="0.1" value="1.0" data-abs-key="playerDmgMult" />
+        <span class="abs-val" data-abs-val="playerDmgMult">1.0x</span>
+      </div>
+
+      <div class="abs-score-row">
+        <span class="abs-score-label">スコア倍率（敵HP×敵ダメ ÷ 自HP×自ダメ）</span>
+        <span class="abs-score-mult" data-abs-score-mult>1.00x</span>
+      </div>
+
+      <div class="abs-buttons">
+        <button type="button" class="action" data-abs-cancel>キャンセル</button>
+        <button type="button" class="action" data-abs-confirm style="background:#a855f7;border-color:#a855f7;">この設定で開始</button>
+      </div>
+    </div>
+  </div>
 
   <div id="helpOverlay" class="hidden" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="helpTitle">
     <div class="help-dialog">

--- a/prototype/js/absolute-config.js
+++ b/prototype/js/absolute-config.js
@@ -1,0 +1,80 @@
+/**
+ * Absolute レギュレーション設定 (SPEC-007)
+ *
+ * ユーザーが任意設定する 4 種の倍率を localStorage に保存する。
+ * - enemyHpMult:    敵 HP 倍率
+ * - enemyDmgMult:   敵ダメージ倍率
+ * - playerHpMult:   自 HP 倍率
+ * - playerDmgMult:  自ダメージ倍率
+ *
+ * 各倍率の有効範囲は MIN_MULT〜MAX_MULT (0.1〜5.0)、step 0.1。
+ */
+
+const LS_KEY = "mct.absoluteConfig";
+
+export const MIN_MULT = 0.1;
+export const MAX_MULT = 5.0;
+export const STEP_MULT = 0.1;
+
+const DEFAULT_CONFIG = {
+  enemyHpMult: 1.0,
+  enemyDmgMult: 1.0,
+  playerHpMult: 1.0,
+  playerDmgMult: 1.0,
+};
+
+function clamp(v) {
+  if (typeof v !== "number" || Number.isNaN(v)) return 1.0;
+  return Math.max(MIN_MULT, Math.min(MAX_MULT, Math.round(v * 10) / 10));
+}
+
+function sanitize(cfg) {
+  return {
+    enemyHpMult:   clamp(cfg?.enemyHpMult),
+    enemyDmgMult:  clamp(cfg?.enemyDmgMult),
+    playerHpMult:  clamp(cfg?.playerHpMult),
+    playerDmgMult: clamp(cfg?.playerDmgMult),
+  };
+}
+
+/** Absolute 設定を取得（無ければデフォルト 1.0x ×4）*/
+export function loadAbsoluteConfig() {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      return sanitize(parsed);
+    }
+  } catch (e) { /* ignore */ }
+  return { ...DEFAULT_CONFIG };
+}
+
+/** Absolute 設定を保存（範囲外は clamp）*/
+export function saveAbsoluteConfig(cfg) {
+  const safe = sanitize(cfg);
+  try { localStorage.setItem(LS_KEY, JSON.stringify(safe)); }
+  catch (e) { /* ignore */ }
+  return safe;
+}
+
+/**
+ * Absolute 倍率からスコア乗数を算出。
+ * 高難易度ほど大きい値を返す:
+ *   (敵 HP × 敵ダメ) / (自 HP × 自ダメ)
+ *
+ * 例: 敵 HP 2.0x, 敵ダメ 1.5x, 自 HP 0.5x, 自ダメ 1.0x
+ *     => (2.0 × 1.5) / (0.5 × 1.0) = 6.0
+ */
+export function getAbsoluteScoreMult(cfg) {
+  const c = sanitize(cfg);
+  const denominator = c.playerHpMult * c.playerDmgMult;
+  if (denominator <= 0) return 1.0;
+  return (c.enemyHpMult * c.enemyDmgMult) / denominator;
+}
+
+/** 既定値リセット用 */
+export function resetAbsoluteConfig() {
+  try { localStorage.removeItem(LS_KEY); }
+  catch (e) { /* ignore */ }
+  return { ...DEFAULT_CONFIG };
+}

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -50,6 +50,14 @@ import {
   unlockNextAfterClear,
 } from "./regulations.js";
 import {
+  loadAbsoluteConfig,
+  saveAbsoluteConfig,
+  getAbsoluteScoreMult,
+  MIN_MULT as ABS_MIN_MULT,
+  MAX_MULT as ABS_MAX_MULT,
+  STEP_MULT as ABS_STEP_MULT,
+} from "./absolute-config.js";
+import {
   resolveCaster,
   canPlayCard,
   unplayableBadge,
@@ -66,6 +74,18 @@ import {
 let currentRegulationId = loadCurrentRegulationId();
 function getCurrentRegulation() {
   return REGULATION_BY_ID[currentRegulationId] || REGULATIONS[0];
+}
+
+/**
+ * SPEC-007: 自ダメージに Absolute の playerDmgMult を乗算するヘルパー。
+ * Absolute 以外のレギュレーションでは恒等 (× 1.0)。
+ */
+function applyPlayerDmgMult(damage) {
+  const reg = getCurrentRegulation();
+  if (!reg.effects.isAbsolute) return damage;
+  const mult = loadAbsoluteConfig().playerDmgMult || 1.0;
+  if (mult === 1.0) return damage;
+  return Math.max(0, Math.round(damage * mult));
 }
 function setCurrentRegulation(id) {
   if (!REGULATION_BY_ID[id]) return;
@@ -715,6 +735,8 @@ function dealPhySkillToEnemy(s, skillPct) {
   if (target === s.enemies?.[0]) {
     total = applyGuardToDamage("enemy", total);
   }
+  // SPEC-007: Absolute レギュレーションの自ダメ倍率を最終ダメージに乗算
+  total = applyPlayerDmgMult(total);
   applyHpDeltaToEnemy(s, target, -total);
   lungePortrait("player", getActiveHero(s));
   flashPortrait("enemy", target);
@@ -747,6 +769,8 @@ function dealIntSkillToEnemy(s, minPct, maxPct, forceCrit = false) {
   if (target === s.enemies?.[0]) {
     total = applyGuardToDamage("enemy", total);
   }
+  // SPEC-007: Absolute レギュレーションの自ダメ倍率を最終ダメージに乗算
+  total = applyPlayerDmgMult(total);
   applyHpDeltaToEnemy(s, target, -total);
   lungePortrait("player", getActiveHero(s));
   flashPortrait("enemy", target);
@@ -1055,6 +1079,15 @@ function ensureRunState() {
       ? pendingPartyConfirmed
       : [LEADER.heroId];
     const party = buildPartyLoadout(partyIds);
+    // SPEC-007: Absolute レギュレーション選択中なら、ヒーロー HP に playerHpMult を適用して runState に反映。
+    const _curReg = REGULATION_BY_ID[loadCurrentRegulationId()] || REGULATIONS[0];
+    const _absHpMult = (_curReg && _curReg.effects.isAbsolute) ? loadAbsoluteConfig().playerHpMult : 1.0;
+    if (_absHpMult !== 1.0) {
+      for (const m of party) {
+        m.hpMax = Math.max(1, Math.round(m.hpMax * _absHpMult));
+        m.hpCurrent = Math.max(1, Math.round(m.hpCurrent * _absHpMult));
+      }
+    }
     runState = {
       chapterIdx: 0,
       deck: makeStarterDeck(),
@@ -1066,6 +1099,8 @@ function ensureRunState() {
       pathNodeIds: [],
       runComplete: false,
       llExtSlots: [null, null],
+      // SPEC-007: ランキング用のターン累計（各戦闘終了時に combat.turn を加算）
+      totalTurns: 0,
     };
   }
 }
@@ -1470,11 +1505,14 @@ function startCombatFromMapNode(node) {
     intentRota = enemyDef.intentRota;
   }
 
-  // レギュレーション効果適用 (#37)
+  // レギュレーション効果適用 (#37)、Absolute は absolute-config.js から読み込み (SPEC-007)
   const reg = getCurrentRegulation();
-  const regHp = Math.max(1, Math.round(enemyDef.hp * reg.effects.hpFactor));
-  const regPhy = Math.max(1, Math.round(enemyDef.phy * reg.effects.atkFactor));
-  const regInt = Math.max(1, Math.round(enemyDef.int * reg.effects.atkFactor));
+  const absConfig = reg.effects.isAbsolute ? loadAbsoluteConfig() : null;
+  const enemyHpFactor  = absConfig ? absConfig.enemyHpMult  : reg.effects.hpFactor;
+  const enemyAtkFactor = absConfig ? absConfig.enemyDmgMult : reg.effects.atkFactor;
+  const regHp = Math.max(1, Math.round(enemyDef.hp * enemyHpFactor));
+  const regPhy = Math.max(1, Math.round(enemyDef.phy * enemyAtkFactor));
+  const regInt = Math.max(1, Math.round(enemyDef.int * enemyAtkFactor));
 
   combat = {
     deck,
@@ -1562,9 +1600,9 @@ function startCombatFromMapNode(node) {
       const pick = pool[Math.floor(Math.random() * pool.length)];
       const def = ENEMY_DEFS[pick];
       if (!def) continue;
-      const subHp = Math.max(1, Math.round(def.hp * reg.effects.hpFactor));
-      const subPhy = Math.max(1, Math.round(def.phy * reg.effects.atkFactor));
-      const subInt = Math.max(1, Math.round(def.int * reg.effects.atkFactor));
+      const subHp = Math.max(1, Math.round(def.hp * enemyHpFactor));
+      const subPhy = Math.max(1, Math.round(def.phy * enemyAtkFactor));
+      const subInt = Math.max(1, Math.round(def.int * enemyAtkFactor));
       combat.enemies.push(makeEnemyUnit({
         position: i,
         defId: def.id,
@@ -5145,6 +5183,9 @@ function endCombatWin() {
   const isBoss = combat.isBoss;
   const isElite = combat.isElite;
 
+  // SPEC-007: ランキング用ターン累計（既存 combat.turn を runState に加算）
+  runState.totalTurns = (runState.totalTurns || 0) + (combat.turn || 1);
+
   // ゴールド
   const earnedGold = isBoss ? chapter.bossRewardGold : isElite ? 45 : 28;
   gold += earnedGold;
@@ -6093,7 +6134,11 @@ function renderRegulationSelect() {
     html += `<div class="rs-card-name" style="color:${r.color}">${r.nameJa}</div>`;
     html += `<div class="rs-card-desc">${r.descShort}</div>`;
     if (isUnlocked) {
-      html += `<button class="rs-select-btn action${isCurrent ? ' rs-select-btn--current' : ''}">${isCurrent ? '選択中' : 'このレギュレーションで始める'}</button>`;
+      // SPEC-007: Absolute は「設定して開始」ボタンに分岐
+      const btnText = r.effects.isAbsolute
+        ? (isCurrent ? '選択中（設定変更）' : 'Absolute を設定して開始')
+        : (isCurrent ? '選択中' : 'このレギュレーションで始める');
+      html += `<button class="rs-select-btn action${isCurrent ? ' rs-select-btn--current' : ''}">${btnText}</button>`;
     } else {
       html += `<div class="rs-locked-hint">前の難易度をクリアで解放</div>`;
     }
@@ -6109,12 +6154,100 @@ function renderRegulationSelect() {
       const card = btn.closest('.rs-card');
       const id = card?.dataset?.regId;
       if (!id) return;
+      // SPEC-007: Absolute なら設定モーダルを開いて、確定後にヒーロー選択へ
+      const reg = REGULATION_BY_ID[id];
+      if (reg && reg.effects.isAbsolute) {
+        openAbsoluteConfigModal(() => {
+          setCurrentRegulation(id);
+          showView("heroSelect");
+          renderHeroSelect();
+        });
+        return;
+      }
       setCurrentRegulation(id);
       showView("heroSelect");
       renderHeroSelect();
     });
   });
 }
+
+/**
+ * SPEC-007: Absolute 設定モーダルを開く。
+ * @param {() => void} onConfirm 確定後コールバック
+ */
+function openAbsoluteConfigModal(onConfirm) {
+  const overlay = document.getElementById("absoluteConfigOverlay");
+  if (!overlay) return;
+  const cur = loadAbsoluteConfig();
+  // 各 slider を現在値で初期化
+  const fields = ["enemyHpMult", "enemyDmgMult", "playerHpMult", "playerDmgMult"];
+  fields.forEach((key) => {
+    const slider = overlay.querySelector(`[data-abs-key="${key}"]`);
+    const valEl = overlay.querySelector(`[data-abs-val="${key}"]`);
+    if (!slider || !valEl) return;
+    slider.value = cur[key].toFixed(1);
+    valEl.textContent = cur[key].toFixed(1) + "x";
+  });
+  updateAbsoluteScoreMultPreview();
+  overlay.classList.remove("hidden");
+  // ボタン bind
+  const cancelBtn = overlay.querySelector("[data-abs-cancel]");
+  const confirmBtn = overlay.querySelector("[data-abs-confirm]");
+  const cleanup = () => {
+    overlay.classList.add("hidden");
+    cancelBtn.removeEventListener("click", onCancel);
+    confirmBtn.removeEventListener("click", onConfirmInner);
+  };
+  const onCancel = () => cleanup();
+  const onConfirmInner = () => {
+    const cfg = {};
+    fields.forEach((key) => {
+      const slider = overlay.querySelector(`[data-abs-key="${key}"]`);
+      cfg[key] = parseFloat(slider.value);
+    });
+    saveAbsoluteConfig(cfg);
+    cleanup();
+    onConfirm && onConfirm();
+  };
+  cancelBtn.addEventListener("click", onCancel);
+  confirmBtn.addEventListener("click", onConfirmInner);
+}
+
+/** Absolute モーダル内の「スコア倍率」プレビュー更新 */
+function updateAbsoluteScoreMultPreview() {
+  const overlay = document.getElementById("absoluteConfigOverlay");
+  if (!overlay) return;
+  const cfg = {};
+  ["enemyHpMult", "enemyDmgMult", "playerHpMult", "playerDmgMult"].forEach((key) => {
+    const slider = overlay.querySelector(`[data-abs-key="${key}"]`);
+    cfg[key] = slider ? parseFloat(slider.value) : 1.0;
+  });
+  const mult = getAbsoluteScoreMult(cfg);
+  const previewEl = overlay.querySelector("[data-abs-score-mult]");
+  if (previewEl) previewEl.textContent = mult.toFixed(2) + "x";
+}
+
+/** SPEC-007: Absolute モーダルのスライダーに input リスナーを 1 度だけ bind */
+(function bindAbsoluteSliderListeners() {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  const setup = () => {
+    const overlay = document.getElementById("absoluteConfigOverlay");
+    if (!overlay) return;
+    overlay.querySelectorAll("input[type='range'][data-abs-key]").forEach((slider) => {
+      slider.addEventListener("input", () => {
+        const key = slider.dataset.absKey;
+        const valEl = overlay.querySelector(`[data-abs-val="${key}"]`);
+        if (valEl) valEl.textContent = parseFloat(slider.value).toFixed(1) + "x";
+        updateAbsoluteScoreMultPreview();
+      });
+    });
+  };
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setup, { once: true });
+  } else {
+    setup();
+  }
+})();
 
 /** ヘッダーの右上（map / combat 両方）に現在のレギュレーションアイコンを表示 (#37) */
 function updateHeaderRegulationIcons() {

--- a/prototype/js/regulations.js
+++ b/prototype/js/regulations.js
@@ -77,6 +77,22 @@ export const REGULATIONS = [
       bleedOnAttack: 1, // 1 スタック
     },
   },
+  {
+    id: "absolute",
+    nameJa: "Absolute",
+    iconUrl: CUP_BASE + "1300.png", // 仮: Red と同じ画像 (cups/1305 が無いため流用)
+    color: "#a855f7",
+    descShort: "ユーザー設定 (敵 HP / 敵ダメ / 自 HP / 自ダメ 倍率を任意調整)",
+    // hpFactor / atkFactor は absolute-config.js から runtime に読み込む。
+    // ここの値は他レギュレーションとシグネチャを揃えるためのフォールバック。
+    effects: {
+      hpFactor: 1.0,
+      atkFactor: 1.0,
+      guardPerTurn: 0,
+      bleedOnAttack: 0,
+      isAbsolute: true,
+    },
+  },
 ];
 
 /** id → regulation の検索辞書 */
@@ -86,16 +102,19 @@ export const REGULATION_BY_ID = Object.fromEntries(REGULATIONS.map((r) => [r.id,
 const LS_UNLOCKED = "mct.unlockedRegulations";
 const LS_CURRENT = "mct.currentRegulation";
 
-/** アンロック済みレギュレーション ID 配列をローカルストレージから取得（無ければ ['common']） */
+/** アンロック済みレギュレーション ID 配列をローカルストレージから取得（無ければ ['common', 'absolute']） */
 export function loadUnlockedRegulations() {
+  let arr = ["common", "absolute"]; // Absolute はユーザー設定型のため最初から開放
   try {
     const raw = localStorage.getItem(LS_UNLOCKED);
     if (raw) {
-      const arr = JSON.parse(raw);
-      if (Array.isArray(arr) && arr.length > 0) return arr;
+      const stored = JSON.parse(raw);
+      if (Array.isArray(stored) && stored.length > 0) arr = stored;
     }
   } catch (e) { /* ignore */ }
-  return ["common"];
+  // 既存セーブで absolute が無い場合に補填
+  if (!arr.includes("absolute")) arr = [...arr, "absolute"];
+  return arr;
 }
 
 /** アンロック状態を保存 */
@@ -130,14 +149,16 @@ export function saveCurrentRegulationId(id) {
 
 /**
  * クリア時のアンロック処理。clearedId をクリアした → 次のレギュレーションをアンロック。
+ * Absolute はクリア報酬の対象外（最初から開放）なので、Red の次として絶対扱いしない。
  * @returns {string|null} 新たにアンロックされた ID（なければ null）
  */
 export function unlockNextAfterClear(clearedId) {
   const idx = REGULATIONS.findIndex((r) => r.id === clearedId);
   if (idx < 0 || idx >= REGULATIONS.length - 1) return null;
-  const nextId = REGULATIONS[idx + 1].id;
+  const next = REGULATIONS[idx + 1];
+  if (!next || next.id === "absolute") return null; // Absolute はアンロック対象外
   const cur = loadUnlockedRegulations();
-  if (cur.includes(nextId)) return null;
-  unlockRegulation(nextId);
-  return nextId;
+  if (cur.includes(next.id)) return null;
+  unlockRegulation(next.id);
+  return next.id;
 }


### PR DESCRIPTION
## Summary

ユーザー設定可能な **6 番目のレギュレーション「Absolute」** を追加。SPEC-007 §4 として仕様確定。

敵 HP / 敵ダメ / 自 HP / 自ダメ の 4 種倍率を 0.1x〜5.0x で任意設定可能。レギュレーション選択画面で「Absolute」を選ぶと設定モーダルが開き、スライダーで調整 → スコア倍率がリアルタイム計算されます。

## 機能詳細

### レギュレーション

- **id**: `absolute`、**color**: 紫 (#a855f7)
- 最初から開放（`loadUnlockedRegulations()` デフォルトに追加）
- `unlockNextAfterClear` ではスキップ（Red クリア後に自動開放されない）
- `effects.isAbsolute: true` フラグで他レギュレーションと識別

### 設定 4 種

| パラメータ | 範囲 | 適用先 |
|---|---|---|
| `enemyHpMult` | 0.1〜5.0 | 敵 HP（既存 `hpFactor` を上書き）|
| `enemyDmgMult` | 0.1〜5.0 | 敵 PHY/INT（既存 `atkFactor` を上書き）|
| `playerHpMult` | 0.1〜5.0 | 自 HP / HPMax（runState 初期化時に乗算）|
| `playerDmgMult` | 0.1〜5.0 | 自ダメ最終値（damage 計算で乗算）|

設定は `localStorage.mct.absoluteConfig` に永続化。

### スコア倍率算出

```
multiplier = (enemyHpMult × enemyDmgMult) / (playerHpMult × playerDmgMult)
```

例: 敵 HP×2.0, 敵ダメ×1.5, 自 HP×0.5, 自ダメ×1.0 → スコア倍率 6.0x

→ PR B（ランキング機能）で使用予定。高難易度設定ほどランキングスコアが高くなる仕組み。

## ファイル変更

- [prototype/js/absolute-config.js](prototype/js/absolute-config.js): 新規モジュール（load/save/sanitize/getScoreMult）
- [prototype/js/regulations.js](prototype/js/regulations.js): Absolute エントリ追加、unlock ロジック調整
- [prototype/js/main.js](prototype/js/main.js):
  - `applyPlayerDmgMult` helper 新設
  - `dealPhySkillToEnemy` / `dealIntSkillToEnemy` で最終ダメに乗算
  - `startCombatFromMapNode` で Absolute なら enemy 倍率を上書き
  - `ensureRunState` で Absolute なら party HP に乗算
  - `renderRegulationSelect` で Absolute クリック時にモーダル開
  - `openAbsoluteConfigModal` / `updateAbsoluteScoreMultPreview` 新設
  - `runState.totalTurns` 追加（PR B 用ターン累計）
  - `endCombatWin` で `totalTurns` 加算
- [prototype/index.html](prototype/index.html): `#absoluteConfigOverlay` 追加（モーダル DOM + CSS）
- [docs/specs/SPEC-007-ranking-and-absolute.md](docs/specs/SPEC-007-ranking-and-absolute.md): 仕様文書

## UI

```
┌─ Absolute レギュレーション設定 ─┐
│ 敵 HP 倍率   [== slider ==] 1.5x │
│ 敵ダメ倍率   [==== slider =====] 2.0x │
│ 自 HP 倍率   [== slider ==] 0.8x │
│ 自ダメ倍率   [==== slider ====] 1.0x │
├──────────────────────────┤
│ スコア倍率（敵HP×敵ダメ ÷ 自HP×自ダメ）3.75x │
├──────────────────────────┤
│  [キャンセル]   [この設定で開始]   │
└──────────────────────────┘
```

## 既存への影響

- 既存 5 レギュレーション（Common / Egg / Baby / Blue / Red）の挙動は完全維持
- `runState.totalTurns` 追加は SPEC-007 §B（ランキング機能）の前準備、本 PR では未使用
- 3v3 / SPEC-006 関連コードは無編集

## Test plan

- [x] `node --check` 全 JS syntax OK
- [x] シミュレータ 50 runs 完走（既存レギュレーション挙動維持）
- [ ] ブラウザで Absolute を選択 → 設定モーダル表示
- [ ] スライダーで倍率調整 → スコア倍率プレビューが動的更新
- [ ] 「この設定で開始」→ 戦闘で倍率が反映（敵 HP / 自ダメ）

## 関連

- 後続 PR: ランキング機能（SPEC-007 §B）
- SPEC: [SPEC-007-ranking-and-absolute.md](docs/specs/SPEC-007-ranking-and-absolute.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)