### PR TITLE
feat(SPEC-006 Phase 4j): passive trigger DSL runtime (codemod 出力待ち)

### DIFF
--- a/docs/specs/SPEC-006-PHASE4-STATUS.md
+++ b/docs/specs/SPEC-006-PHASE4-STATUS.md
@@ -22,7 +22,7 @@
 | 4g | Phase 3j 撤去 | P0 | ✅ **完了** | setActiveHero / getActiveHero / ensureActiveHeroAlive / loadActiveHeroStatsToLegacy / syncLegacyStatsToActiveHero / activeHeroIdx を全削除。portrait click handler + ▶ ACTIVE バッジ + hover lift CSS も撤去。getActiveHero 利用箇所は transient な `combat._currentCaster` (playCard スコープ) に置換 |
 | 4h | バトル外カード券面 effects ベース統一 + caster ロール表示 | P1 | ✅ **完了** | buildRewardPickButton (リワード/デッキ/ショップ/クラフト共通) と showOwnedDeckPeek を effects 配列 + caster ロールラベル ベースに更新。バトル外は具体ヒーロー portrait は出さず「先頭」「前衛」等のロール pill のみ表示 |
 | 4i | 577 カード手動 caster 再指定 | P2 | 未着手 | content PR 全マージ完了済み (PR #51/#56)、差別化したいものを手動再指定 |
-| 4j | パッシブ trigger DSL 統合 (codemod) | P0 | 未着手 | PR #55 マージ済み (Rare hero 53)、計 113 関数を codemod 対象 |
+| 4j | パッシブ trigger DSL 統合 (codemod) | P0 | **runtime 完成、codemod 出力待ち** | passive-runtime.js + 12 種 effect handler + 5 件サンプル変換完了。content 担当の codemod 出力 (210 関数 → PassiveDef) を待って既存 hardcoded 関数を全削除 |
 
 ### 完了済みフェーズの動作確認済み事項 (Phase 4a-4d)
 
@@ -80,6 +80,33 @@
 - 効果テキストは effects[].text を simplifyEffectText で整形、effects 未定義時は旧 effectSummaryLines にフォールバック
 - showOwnedDeckPeek (タップ tooltip) も「使い手: 先頭」のロール表記を opc-meta に追加
 - reward-card-inner 用 CSS で effect-row のフォントサイズを container query で大きめに調整 (バトル中より見やすく)
+
+### Phase 4j の進捗 (runtime 完成、codemod 出力待ち)
+
+- **passive-runtime.js** 新設:
+  - `registerPassives(defs)` / `registerEffectHandlers(handlers)` で外部注入
+  - `applyPassiveTrigger(s, kind, ctx)` で trigger 別 dispatch
+  - `applyPassiveEffect(s, caster, effect)` で effect ごとの dispatch
+  - `checkPassiveThresholds(s, hero)` で HP/statRatio 閾値ベース判定
+  - oncePerCombat 管理 (hero.passiveTriggered Set)、triggerRate (確率発動)
+- **12 種 effect handler 実装** (PASSIVE_EFFECT_HANDLERS in main.js):
+  damage / damageRaw / damageMaxHpPct / heal / healRaw / applyStatus /
+  buffStat / addGuard / addShield / addEnergy / drawCards / revive / clearStatus + showCutin
+- **passives-sample.js** 新設: 5 件手動変換 (kaihime / zhang / doyle / seton / schubert)
+  → 復活系 schubert は §18.6.3 case A (hasResurrection 廃止) で revive action を直接実行
+- **既存 hook 点に applyPassiveTrigger 設置**:
+  - startCombatFromMapNode 末尾: `combat.started`
+  - playCard 末尾: `self.cardPlayed` (caster 一致のみ発動)
+  - dealPhy/IntSkillFromEnemyToPlayer 末尾: `self.tookDamage` (target=被弾ヒーロー)
+  - applyHpDeltaToHero 内 alive=false 化直後: `self.died` (§18.6.1 同期実行)
+  - applyHpDeltaToHero 内 HP 減少時: `checkPassiveThresholds` で self.hpBelow / party.hpBelow / enemy.hpBelow / self.statRatioAbove を判定
+- **既存 hardcoded apply\*Passive 関数群は維持** (PASSIVES 出力到着までの保険)
+  → Phase 4j 完了時に codemod 出力で全 210 関数を一括削除予定
+
+### Phase 4j 残作業 (content 担当依頼中: HANDOFF-PHASE4J-KICKOFF.md)
+- 依頼 1: 210 関数 → PassiveDef 変換 codemod スクリプト + 出力 (passives-generated.js)
+- 依頼 2: caster × trigger 対応表 (Epic / Legendary)
+- 依頼 3: triggerRate 元 DB 値抽出
 
 ## 完了した事前準備物 (このブランチ)
 

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -64,6 +64,13 @@ import {
   CASTER_ROLE_LABELS,
 } from "./caster.js";
 import {
+  registerPassives,
+  registerEffectHandlers,
+  applyPassiveTrigger,
+  checkPassiveThresholds,
+} from "./passive-runtime.js";
+import { SAMPLE_PASSIVES } from "./passives-sample.js";
+import {
   loadTargetLabels,
   targetLabelText,
   targetColorVar,
@@ -822,13 +829,20 @@ function getEnemyAttackTargetHero(s) {
 /** ヒーローユニットの hp / alive を更新し、必要に応じて legacy フィールドを同期する。 */
 function applyHpDeltaToHero(s, hero, delta) {
   if (!hero) return;
+  const wasAlive = hero.alive !== false && (hero.hp ?? 0) > 0;
   hero.hp = Math.max(0, (hero.hp ?? 0) + delta);
   if (hero.hp <= 0) hero.alive = false;
   // heroes[0] (前衛) なら legacy combat.playerHp と同期
   if (s.heroes && hero === s.heroes[0]) {
     s.playerHp = hero.hp;
   }
-  // SPEC-006 Phase 4g: アクティブキャスター方式は廃止。caster は毎回カード定義から解決される。
+  // SPEC-006 §18.6.1: 同期実行制約 — self.died trigger は同関数内で発動
+  // (revive 系パッシブが alive=true に戻すため、UI 上「死亡 → 復活」が瞬間的に見える)
+  if (wasAlive && hero.alive === false) {
+    applyPassiveTrigger(s, "self.died", { hero });
+  }
+  // §18.6: HP 閾値ベースの trigger (self.hpBelow / party.hpBelow / enemy.hpBelow) チェック
+  if (delta < 0) checkPassiveThresholds(s, hero);
 }
 
 /** 全ヒーロー死亡判定 */
@@ -945,6 +959,10 @@ function dealPhySkillFromEnemyToPlayer(s, skillPct, caster) {
   if (LEADER.passiveKey === 'zhang' && s.playerHp > 0 && s.enemyHp > 0 && Math.random() < 0.5) {
     s._zhangCounterPending = true;
   }
+  // SPEC-006 §18.6: 被弾ヒーローの self.tookDamage trigger
+  if (target && target.alive !== false && (target.hp ?? 0) > 0) {
+    applyPassiveTrigger(s, "self.tookDamage", { hero: target });
+  }
 }
 
 function dealIntSkillFromEnemyToPlayer(s, skillPct, caster) {
@@ -977,6 +995,10 @@ function dealIntSkillFromEnemyToPlayer(s, skillPct, caster) {
   // 張遼パッシブ判定フラグを立てる（実際の反撃は enemyTurn で async に処理）
   if (LEADER.passiveKey === 'zhang' && s.playerHp > 0 && s.enemyHp > 0 && Math.random() < 0.5) {
     s._zhangCounterPending = true;
+  }
+  // SPEC-006 §18.6: 被弾ヒーローの self.tookDamage trigger
+  if (target && target.alive !== false && (target.hp ?? 0) > 0) {
+    applyPassiveTrigger(s, "self.tookDamage", { hero: target });
   }
 }
 
@@ -1049,6 +1071,192 @@ const battleApi = {
 };
 
 const { CARD_LIBRARY, copyCard, makeStarterDeck } = createCardRuntime(clog, battleApi);
+
+// ─── SPEC-006 Phase 4j: PassiveDef effect action ハンドラ ──────────
+// passive-runtime.js が dispatch する effect.action 種別を実装。
+// 引数: (s = combat, caster = passive を持つ hero, target = effect 適用対象, effect = effect entry)
+const PASSIVE_EFFECT_HANDLERS = {
+  // damage: PHY/INT 倍率の物理/魔法ダメージ
+  damage(s, caster, target, effect) {
+    const phyCoef = effect.coef?.phy || 0;
+    const intCoef = effect.coef?.int || 0;
+    let dmg = 0;
+    if (phyCoef > 0) dmg += Math.max(1, Math.floor((caster.phy ?? 0) * phyCoef));
+    if (intCoef > 0) dmg += Math.max(1, Math.floor((caster.int ?? 0) * intCoef));
+    if (dmg <= 0) return;
+    if (target.side === "enemy") {
+      applyHpDeltaToEnemy(s, target, -dmg);
+      playPortraitEffect("enemy", "hit", target);
+    } else {
+      applyHpDeltaToHero(s, target, -dmg);
+      playPortraitEffect("player", "hit", target);
+    }
+    playBattleSe("hit");
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} に ${dmg} ダメ`);
+  },
+
+  // damageRaw: 固定値ダメージ
+  damageRaw(s, caster, target, effect) {
+    const dmg = Math.max(1, effect.value || 0);
+    if (target.side === "enemy") applyHpDeltaToEnemy(s, target, -dmg);
+    else applyHpDeltaToHero(s, target, -dmg);
+    playBattleSe("hit");
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} に ${dmg} ダメ (固定)`);
+  },
+
+  // damageMaxHpPct: 最大 HP の N% 特殊ダメージ
+  damageMaxHpPct(s, caster, target, effect) {
+    const pct = effect.pct || 0;
+    const dmg = Math.max(1, Math.floor((target.hpMax || 0) * pct / 100));
+    if (target.side === "enemy") applyHpDeltaToEnemy(s, target, -dmg);
+    else applyHpDeltaToHero(s, target, -dmg);
+    playBattleSe("area");
+    playPortraitEffect(target.side === "enemy" ? "enemy" : "player", "area", target);
+    clog(`【${caster.name || "パッシブ"}】 特殊ダメ ${pct}% → ${dmg}`);
+  },
+
+  // heal: INT 倍率 or HP 倍率の回復
+  heal(s, caster, target, effect) {
+    const intCoef = effect.coef?.int || 0;
+    const hpCoef = effect.coef?.hp || 0;
+    let amt = 0;
+    if (intCoef > 0) amt += Math.max(1, Math.floor((caster.int ?? 0) * intCoef));
+    if (hpCoef > 0) amt += Math.max(1, Math.floor((target.hpMax || 0) * hpCoef));
+    if (amt <= 0) return;
+    applyHpDeltaToHero(s, target, +amt);
+    playPortraitEffect("player", "heal", target);
+    playBattleSe("heal");
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} HP+${amt}`);
+  },
+
+  // healRaw: 固定値回復
+  healRaw(s, caster, target, effect) {
+    const amt = Math.max(1, effect.value || 0);
+    applyHpDeltaToHero(s, target, +amt);
+    playPortraitEffect("player", "heal", target);
+    playBattleSe("heal");
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} HP+${amt}`);
+  },
+
+  // applyStatus: 状態異常付与 (poison/bleed/vulnerable)
+  applyStatus(s, caster, target, effect) {
+    const stacks = effect.stacks || 1;
+    if (target.side === "enemy") {
+      const field = { poison: "poison", bleed: "bleed", vulnerable: "vulnerable" }[effect.status];
+      if (!field) return;
+      target[field] = (target[field] || 0) + stacks;
+      if (s.enemies?.[0] === target) {
+        if (field === "poison") s.enemyPoison = target.poison;
+        else if (field === "bleed") s.enemyBleed = target.bleed;
+        else if (field === "vulnerable") s.enemyVulnerable = target.vulnerable;
+      }
+    } else {
+      addStatusToHero(s, target, effect.status, stacks);
+    }
+    playBattleSe("debuff");
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} に ${effect.status} ×${stacks}`);
+  },
+
+  // buffStat: ステ加算 (stat: phy/int/agi、value 定数 or coef 倍率)
+  buffStat(s, caster, target, effect) {
+    const field = { phy: "phy", int: "int", agi: "agi" }[effect.stat];
+    if (!field) return;
+    let delta = effect.value;
+    if (delta == null && effect.coef != null) {
+      const baseField = field + "Base";
+      delta = Math.max(1, Math.floor((target[baseField] ?? target[field] ?? 0) * effect.coef));
+    }
+    if (!delta) return;
+    target[field] = (target[field] ?? 0) + delta;
+    // 法 mirror
+    if (s.heroes?.[0] === target) {
+      if (field === "phy") s.playerPhy = target.phy;
+      else if (field === "int") s.playerInt = target.int;
+      else if (field === "agi") s.playerAgi = target.agi;
+    }
+    playBattleSe("buff");
+    playPortraitEffect("player", "buff", target);
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} ${effect.stat.toUpperCase()} ${delta >= 0 ? "+" : ""}${delta}`);
+  },
+
+  // addGuard: ガード付与
+  addGuard(s, caster, target, effect) {
+    const v = effect.value || 0;
+    target.guard = (target.guard || 0) + v;
+    if (s.heroes?.[0] === target) s.playerGuard = target.guard;
+    playBattleSe("buff");
+    playPortraitEffect("player", "buff", target);
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} ガード +${v}`);
+  },
+
+  // addShield: シールド付与
+  addShield(s, caster, target, effect) {
+    const v = effect.value || 0;
+    target.shield = (target.shield || 0) + v;
+    if (s.heroes?.[0] === target) s.playerShield = target.shield;
+    playBattleSe("buff");
+    playPortraitEffect("player", "buff", target);
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} シールド +${v}`);
+  },
+
+  // addEnergy: エナジー +N (即時 or 次ターン)
+  addEnergy(s, caster, target, effect) {
+    const v = effect.value || 0;
+    if (effect.nextTurn) {
+      s.bonusEnergyNext = (s.bonusEnergyNext || 0) + v;
+      clog(`【${caster.name || "パッシブ"}】 次ターン ⚡+${v}`);
+    } else {
+      s.energy = Math.min(s.energy + v, (s.energyMax || 3) + 3);
+      clog(`【${caster.name || "パッシブ"}】 ⚡+${v}`);
+    }
+  },
+
+  // drawCards: カード ドロー
+  drawCards(s, caster, target, effect) {
+    const v = effect.value || 0;
+    drawCards(s, v);
+    clog(`【${caster.name || "パッシブ"}】 ドロー +${v}`);
+  },
+
+  // revive: 復活 (self.died trigger 専用、§18.6.1 同期実行)
+  // hpRatio で hpMax × N% 回復、alive=true 復元
+  revive(s, caster, target, effect) {
+    const ratio = effect.coef?.hpRatio || 0.2;
+    const heal = Math.max(1, Math.floor((target.hpMax || 0) * ratio));
+    target.hp = Math.min(target.hpMax || target.hp, target.hp + heal);
+    target.alive = true;
+    if (s.heroes?.[0] === target) s.playerHp = target.hp;
+    playBattleSe("heal");
+    playPortraitEffect("player", "heal", target);
+    clog(`【${caster.name || "パッシブ"}】 復活！ HP+${heal}`);
+  },
+
+  // clearStatus: 状態異常解除
+  clearStatus(s, caster, target, effect) {
+    const which = effect.status || "all";
+    if (which === "all" || which === "poison") {
+      target.poison = 0;
+      if (s.heroes?.[0] === target) s.playerPoison = 0;
+    }
+    if (which === "all" || which === "bleed") {
+      target.bleed = 0;
+      if (s.heroes?.[0] === target) s.playerBleed = 0;
+    }
+    if (which === "all" || which === "vulnerable") {
+      target.vulnerable = 0;
+      if (s.heroes?.[0] === target) s.playerVulnerable = 0;
+    }
+    playBattleSe("heal");
+    clog(`【${caster.name || "パッシブ"}】 ${target.name || ""} 状態異常解除`);
+  },
+
+  // showCutin (effect ではないが、PassiveDef.cutinSkillName のためのフック)
+  showCutin(hero, skillName) {
+    clog(`【${skillName}】発動！`);
+    // showPassiveCutin の重い演出を呼びたい場合はここで await できないので
+    // 簡略化として clog のみ。Phase 4j 完成時に必要なら拡張。
+  },
+};
 
 // ─── ランステート管理 ─────────────────────────────────────────────
 function ensureRunState() {
@@ -1625,6 +1833,9 @@ function startCombatFromMapNode(node) {
     clog(`ボスはシールド ${enemyDef.initialShield} を持ちます！`);
   }
   applyHeroPassiveOnCombatStart(combat);
+  // SPEC-006 §18.6: PassiveDef DSL の combat.started trigger を発動
+  // (登録済みの SAMPLE_PASSIVES のみ。既存 hardcoded 関数とは独立に動作)
+  applyPassiveTrigger(combat, "combat.started");
   syncLlExtSlots();
   startPlayerTurn();
 }
@@ -4990,6 +5201,10 @@ async function playCard(idx) {
   await applyHeroPassiveOnCardUse(combat);
   if (!combat) return;
   if (areAllEnemiesDefeated(combat)) { endCombatWin(); return; }
+  // SPEC-006 §18.6: PassiveDef DSL の self.cardPlayed trigger
+  // (caster を渡し、発動対象は caster と一致する hero のみに限定)
+  applyPassiveTrigger(combat, "self.cardPlayed", { caster, card });
+  if (areAllEnemiesDefeated(combat)) { endCombatWin(); return; }
   renderCombat();
 }
 
@@ -6969,6 +7184,11 @@ function init() {
   loadTargetLabels()
     .then(() => applyCssVariables())
     .catch(err => console.warn("[target-labels] load failed", err));
+
+  // SPEC-006 Phase 4j: passive runtime の effect handler を注入 + サンプル登録
+  // codemod 出力 (passives-generated.js) が来たらここで一括 register に置き換える
+  registerEffectHandlers(PASSIVE_EFFECT_HANDLERS);
+  registerPassives(SAMPLE_PASSIVES);
 }
 
 init();

--- a/prototype/js/passive-runtime.js
+++ b/prototype/js/passive-runtime.js
@@ -1,0 +1,165 @@
+/**
+ * passive-runtime.js — SPEC-006 §18: パッシブ trigger DSL の実行系
+ *
+ * `prototype/data/passives.js` (codemod 出力) で定義された PassiveDef を
+ * 戦闘中の各 hook 点から dispatch する。
+ *
+ * 同期実行制約 (§18.6.1):
+ *   `self.died` trigger は applyHpDeltaToHero 内で同期発動する必要がある。
+ */
+
+import { resolveTargets } from "./targeting.js";
+
+// ─── PassiveDef レジストリ ──────────────────────────────────────────
+// 暫定: 当方の手動変換サンプル + content 担当 codemod 出力 (passives-generated.js) を統合
+// Phase 4j マージ時に passives-generated.js を import して PASSIVES に展開する。
+let PASSIVE_REGISTRY = {};
+
+/** PassiveDef を登録 (アプリ起動時に呼ぶ) */
+export function registerPassives(defs) {
+  if (!defs) return;
+  for (const [key, def] of Object.entries(defs)) {
+    PASSIVE_REGISTRY[key] = def;
+  }
+}
+
+export function getRegisteredPassive(passiveKey) {
+  return PASSIVE_REGISTRY[passiveKey] || null;
+}
+
+/** デバッグ用: 登録済みパッシブ一覧 */
+export function _debugListPassives() { return Object.keys(PASSIVE_REGISTRY); }
+
+// ─── trigger 種別 (§18.1) ──────────────────────────────────────────
+// combat.started / self.cardPlayed / self.tookDamage / self.died /
+// self.hpBelow / party.hpBelow / enemy.hpBelow / self.statRatioAbove /
+// enemy.cardPlayed
+
+// ─── trigger ごとのフィルタ ─────────────────────────────────────────
+
+/** trigger と現在の戦闘状態を見て発動可否を判定 */
+function shouldFire(s, hero, def, ctx = {}) {
+  if (!hero || hero.alive === false || (hero.hp ?? 0) <= 0) {
+    // self.died は死亡時の発動なので生存チェックを除外
+    if (def.trigger !== "self.died") return false;
+  }
+  // oncePerCombat
+  if (def.oncePerCombat !== false) {
+    if (!hero.passiveTriggered) hero.passiveTriggered = {};
+    if (hero.passiveTriggered[def.passiveKey]) return false;
+  }
+  // triggerRate (確率発動)
+  const rate = def.triggerRate;
+  if (typeof rate === "number" && rate < 1) {
+    if (Math.random() >= rate) return false;
+  }
+  // threshold 系
+  if (def.trigger === "self.hpBelow" && def.threshold != null) {
+    if ((hero.hp / hero.hpMax) >= def.threshold) return false;
+  }
+  if (def.trigger === "party.hpBelow" && def.threshold != null) {
+    const total = (s.heroes || []).reduce((sum, h) => sum + (h?.hp ?? 0), 0);
+    const totalMax = (s.heroes || []).reduce((sum, h) => sum + (h?.hpMax ?? 0), 0);
+    if (totalMax === 0 || (total / totalMax) >= def.threshold) return false;
+  }
+  if (def.trigger === "enemy.hpBelow" && def.threshold != null) {
+    const total = (s.enemies || []).reduce((sum, e) => sum + (e?.hp ?? 0), 0);
+    const totalMax = (s.enemies || []).reduce((sum, e) => sum + (e?.hpMax ?? 0), 0);
+    if (totalMax === 0 || (total / totalMax) >= def.threshold) return false;
+  }
+  if (def.trigger === "self.statRatioAbove" && def.threshold != null) {
+    const cur = (hero.phy || 0) + (hero.int || 0) + (hero.agi || 0);
+    const base = (hero.phyBase || 0) + (hero.intBase || 0) + (hero.agiBase || 0);
+    if (base === 0 || (cur / base) < def.threshold) return false;
+  }
+  return true;
+}
+
+/** 発動マーク */
+function markTriggered(hero, def) {
+  if (def.oncePerCombat === false) return;
+  if (!hero.passiveTriggered) hero.passiveTriggered = {};
+  hero.passiveTriggered[def.passiveKey] = true;
+}
+
+// ─── effect 実行 ────────────────────────────────────────────────────
+// effects: [{ target, action, ...params }]
+// dependent on combat helpers (applyHpDeltaToHero / applyHpDeltaToEnemy / addStatusToHero)
+// → exporting registerEffectHandlers で main.js から後で注入
+
+let _effectHandlers = null;
+
+/** main.js が起動時に effect handler を注入する */
+export function registerEffectHandlers(handlers) {
+  _effectHandlers = handlers;
+}
+
+/** 単一 effect を実行 */
+export function applyPassiveEffect(s, caster, effect) {
+  if (!_effectHandlers) {
+    console.warn("[passive-runtime] effect handlers not registered yet");
+    return;
+  }
+  const targets = resolveTargets(effect.target, caster, s);
+  if (!targets || targets.length === 0) return;
+  const handler = _effectHandlers[effect.action];
+  if (typeof handler !== "function") {
+    console.warn(`[passive-runtime] unknown action: ${effect.action}`);
+    return;
+  }
+  for (const tgt of targets) {
+    try { handler(s, caster, tgt, effect); }
+    catch (e) { console.error(`[passive-runtime] action ${effect.action} failed`, e); }
+  }
+}
+
+// ─── trigger dispatch ───────────────────────────────────────────────
+
+/** 全ヒーロー (oncePerCombat 管理は §18 の hero.passiveTriggered Set) を scan し、
+ *  trigger に合致する PassiveDef を 1 回 dispatch する。
+ *  ctx は trigger 種別ごとの追加情報 (caster card など) */
+export function applyPassiveTrigger(s, kind, ctx = {}) {
+  if (!s) return;
+  const heroes = s.heroes || [];
+  // self.cardPlayed のような hook では ctx.caster (=カード使用者) を優先
+  // それ以外は scan (各 hero の passiveKey を見て登録済みなら発動候補)
+  for (const hero of heroes) {
+    if (!hero) continue;
+    const def = getRegisteredPassive(hero.passiveKey);
+    if (!def || def.trigger !== kind) continue;
+    // self.cardPlayed なら caster と一致するヒーローのみ
+    if (kind === "self.cardPlayed" && ctx.caster && hero !== ctx.caster) continue;
+    // self.tookDamage なら被弾ヒーローのみ
+    if (kind === "self.tookDamage" && ctx.hero && hero !== ctx.hero) continue;
+    // self.died なら死亡ヒーローのみ
+    if (kind === "self.died" && ctx.hero && hero !== ctx.hero) continue;
+    if (!shouldFire(s, hero, def, ctx)) continue;
+
+    // 発動: cutin → effects 順次実行
+    if (def.cutinSkillName && _effectHandlers?.showCutin) {
+      _effectHandlers.showCutin(hero, def.cutinSkillName);
+    }
+    for (const effect of def.effects || []) {
+      applyPassiveEffect(s, hero, effect);
+    }
+    markTriggered(hero, def);
+  }
+}
+
+/** HP/statRatio 系の閾値ベース trigger を hero 状態変化のたびにチェック
+ *  (applyHpDeltaToHero などから呼ぶ) */
+export function checkPassiveThresholds(s, hero) {
+  if (!s || !hero) return;
+  const def = getRegisteredPassive(hero.passiveKey);
+  if (!def) return;
+  if (!["self.hpBelow", "party.hpBelow", "enemy.hpBelow", "self.statRatioAbove"].includes(def.trigger)) return;
+  if (!shouldFire(s, hero, def)) return;
+
+  if (def.cutinSkillName && _effectHandlers?.showCutin) {
+    _effectHandlers.showCutin(hero, def.cutinSkillName);
+  }
+  for (const effect of def.effects || []) {
+    applyPassiveEffect(s, hero, effect);
+  }
+  markTriggered(hero, def);
+}

--- a/prototype/js/passives-sample.js
+++ b/prototype/js/passives-sample.js
@@ -1,0 +1,75 @@
+/**
+ * passives-sample.js — SPEC-006 §18: 動作確認用の手動変換サンプル
+ *
+ * Phase 4j 完了時には content 担当の codemod 出力 (passives-generated.js) で
+ * 全 210 体を一括変換する。本ファイルは runtime の単体動作確認用。
+ *
+ * 既存 hardcoded apply*Passive 関数からの変換例:
+ * - kaihime, zhang, doyle: 既存 3 体 (legacy → DSL)
+ * - seton (1004 Common): combat.started + damage + status
+ * - schubert (2004 Uncommon): self.died + revive (case A: hasResurrection 廃止)
+ */
+
+export const SAMPLE_PASSIVES = {
+  // ─── Common (legacy 3 体: kaihime / zhang / doyle) ────────────
+  // 甲斐姫 (1002): 自身がカード使用後、50% で先頭敵に PHY×0.5 追加ダメ
+  kaihime: {
+    passiveKey: "kaihime",
+    trigger: "self.cardPlayed",
+    triggerRate: 0.50,
+    oncePerCombat: false, // カード使用ごとに判定 (繰り返し発動)
+    effects: [
+      { target: "enemy.foremost", action: "damage", coef: { phy: 0.5 } },
+    ],
+    cutinSkillName: "浪切",
+  },
+
+  // 張遼 (1003): 被ダメ後 50% で反撃 (PHY×0.2)
+  zhang: {
+    passiveKey: "zhang",
+    trigger: "self.tookDamage",
+    triggerRate: 0.50,
+    oncePerCombat: false,
+    effects: [
+      { target: "enemy.foremost", action: "damage", coef: { phy: 0.2 } },
+    ],
+    cutinSkillName: "遼来遼来",
+  },
+
+  // コナン・ドイル (1001): HP < 70% で 1 回だけ INT +3
+  doyle: {
+    passiveKey: "doyle",
+    trigger: "self.hpBelow",
+    threshold: 0.70,
+    oncePerCombat: true,
+    effects: [
+      { target: "self", action: "buffStat", stat: "int", value: 3 },
+    ],
+    cutinSkillName: "シャーロック・ホームズ",
+  },
+
+  // ─── Common (PR #50 サンプル) ──────────────────────────────────
+  // シートン (1004): 戦闘開始時、敵に INT 40% ダメージ + 出血 1
+  seton: {
+    passiveKey: "seton",
+    trigger: "combat.started",
+    oncePerCombat: true,
+    effects: [
+      { target: "enemy.foremost", action: "damage", coef: { int: 0.4 } },
+      { target: "enemy.foremost", action: "applyStatus", status: "bleed", stacks: 1 },
+    ],
+    cutinSkillName: "狼王ロボ",
+  },
+
+  // ─── Uncommon (PR #52 復活系サンプル) ──────────────────────────
+  // シューベルト (2004): 死亡時に HP 20% で復活 (hasResurrection フラグ廃止)
+  schubert: {
+    passiveKey: "schubert",
+    trigger: "self.died",
+    oncePerCombat: true,
+    effects: [
+      { target: "self", action: "revive", coef: { hpRatio: 0.20 } },
+    ],
+    cutinSkillName: "魔王",
+  },
+};


### PR DESCRIPTION
## Summary

[SPEC-006 §18](docs/specs/SPEC-006-card-caster.md) のパッシブ trigger DSL の **runtime 部分** を実装。content 担当の codemod 出力 (210 関数 → PassiveDef オブジェクト群) が来たら register するだけで全パッシブが宣言形式で動作する基盤。

## Changes

### `prototype/js/passive-runtime.js` (新規)
- `registerPassives(defs)` / `registerEffectHandlers(handlers)` で外部注入
- `applyPassiveTrigger(s, kind, ctx?)` で trigger 別 dispatch
  - oncePerCombat / triggerRate / threshold (hpBelow/statRatioAbove) 管理
  - self.cardPlayed なら ctx.caster 一致のみ、self.tookDamage なら ctx.hero 一致のみ
- `applyPassiveEffect(s, caster, effect)` で effect.action ごとに handler dispatch
- `checkPassiveThresholds(s, hero)` で HP/statRatio 系の都度チェック

### `prototype/js/main.js`
- **PASSIVE_EFFECT_HANDLERS** 定義 (12 種 + showCutin):
  - `damage` / `damageRaw` / `damageMaxHpPct`
  - `heal` / `healRaw`
  - `applyStatus` (poison/bleed/vulnerable)
  - `buffStat` (phy/int/agi、value or coef)
  - `addGuard` / `addShield` / `addEnergy` / `drawCards`
  - `revive` (§18.6.3 case A: hasResurrection 廃止対応)
  - `clearStatus`
- 既存 hook 点に `applyPassiveTrigger` 設置:
  - `startCombatFromMapNode` 末尾: `combat.started`
  - `playCard` 末尾: `self.cardPlayed` (caster 一致のみ)
  - `dealPhy/IntSkillFromEnemyToPlayer` 末尾: `self.tookDamage`
  - `applyHpDeltaToHero` alive=false 化直後: `self.died` (§18.6.1 同期実行)
  - `applyHpDeltaToHero` HP 減少時: `checkPassiveThresholds`

### `prototype/js/passives-sample.js` (新規)
動作確認用の手動変換サンプル 5 件:
| passiveKey | trigger | rate | effects |
|---|---|---|---|
| kaihime | self.cardPlayed | 0.50 | damage (PHY×0.5) |
| zhang | self.tookDamage | 0.50 | damage (PHY×0.2) |
| doyle | self.hpBelow | (threshold 0.7) | buffStat INT+3 |
| seton | combat.started | (1回) | damage + applyStatus bleed |
| schubert | **self.died** | (1回) | **revive** (hpRatio 0.20) |

## 動作モード (重要)

**既存 hardcoded `apply*Passive` 関数群はそのまま維持**。SAMPLE_PASSIVES 5 件のみ DSL 経由で発動するため、サンプル該当キャラ (甲斐姫/張遼/コナン・ドイル/シートン/シューベルト) を使うと **DSL + 既存関数の両方** が発動 (重複)。

→ Phase 4j 完了時に content 担当の codemod 出力 (PASSIVES) で SAMPLE_PASSIVES を置換し、既存 209 関数を一括削除する想定。

## content 担当への依頼

[`mct-extensions/HANDOFF-PHASE4J-KICKOFF.md`](https://github.com/bearko/mct-extensions) で正式依頼済み:
1. **210 関数 → PassiveDef 変換 codemod スクリプト + 出力 (passives-generated.js)**
2. caster × trigger 対応表 (Epic / Legendary)
3. triggerRate 元 DB 値抽出

action 語彙提案も含めて 13 種で過不足ない想定。Epic/Legendary で新 action が必要ならリスト拡張。

## Test plan
- [ ] 既存戦闘 (LEADER=甲斐姫) でスキルカード使用後、**DSL 経由 + 既存関数の両方** から「浪切」が 50% で発動 (= 重複発動を確認)
- [ ] LEADER=シートン で戦闘開始時、敵に INT 40% ダメ + 出血 1 が DSL 経由で適用
- [ ] LEADER=シューベルト で致死ダメージを受けた瞬間、HP 20% で復活 (§18.6.1 同期実行確認)
- [ ] LEADER=コナン・ドイル で HP 70% 未満になった瞬間、INT +3
- [ ] LEADER=張遼 で被ダメ後 50% で反撃ダメ
- [ ] passive-runtime.js の syntax ok (node --check)
- [ ] init() で SAMPLE_PASSIVES 登録 + EFFECT_HANDLERS 注入が走る

## 次フェーズ (Phase 4j 残作業)
- content 担当の codemod 出力到着待ち
- 到着後: SAMPLE_PASSIVES → PASSIVES 置換、hardcoded 関数 209 個削除
- 統合テスト (各レアリティ 5-10 体ずつ)
- Phase 4j マージ → SPEC-006 全完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)