### PR TITLE
feat(card-preview): hover/focus 時にターゲットを枠ハイライト + 予測値表示

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -376,6 +376,55 @@
     }
     .combatant-portrait--enemy { background: transparent; }
 
+    /* SPEC-006 UX: カード hover 時のターゲット予告 (枠ハイライト + 予測値オーバーレイ) */
+    .combatant-portrait-wrap.preview-target-damage {
+      outline: 3px solid rgba(231, 96, 96, 0.95);
+      outline-offset: 2px;
+      box-shadow: 0 0 14px rgba(231, 96, 96, 0.6);
+      animation: preview-pulse-damage 1.2s ease-in-out infinite;
+    }
+    .combatant-portrait-wrap.preview-target-status {
+      outline: 3px solid rgba(196, 50, 100, 0.95);
+      outline-offset: 2px;
+      box-shadow: 0 0 14px rgba(196, 50, 100, 0.55);
+    }
+    .combatant-portrait-wrap.preview-target-heal {
+      outline: 3px solid rgba(126, 217, 87, 0.95);
+      outline-offset: 2px;
+      box-shadow: 0 0 14px rgba(126, 217, 87, 0.6);
+      animation: preview-pulse-heal 1.2s ease-in-out infinite;
+    }
+    .combatant-portrait-wrap.preview-target-buff {
+      outline: 3px solid rgba(196, 163, 90, 0.95);
+      outline-offset: 2px;
+      box-shadow: 0 0 14px rgba(196, 163, 90, 0.55);
+    }
+    @keyframes preview-pulse-damage {
+      0%, 100% { box-shadow: 0 0 14px rgba(231, 96, 96, 0.6); }
+      50%      { box-shadow: 0 0 22px rgba(231, 96, 96, 0.9); }
+    }
+    @keyframes preview-pulse-heal {
+      0%, 100% { box-shadow: 0 0 14px rgba(126, 217, 87, 0.6); }
+      50%      { box-shadow: 0 0 22px rgba(126, 217, 87, 0.9); }
+    }
+    .preview-overlay {
+      position: absolute;
+      top: -10px; left: 50%;
+      transform: translateX(-50%);
+      font-weight: 800;
+      font-size: clamp(0.7rem, 1.2vw, 1rem);
+      pointer-events: none;
+      z-index: 60;
+      padding: 1px 6px; border-radius: 6px;
+      background: rgba(10,6,16,0.92);
+      letter-spacing: 0.02em;
+      white-space: nowrap;
+    }
+    .preview-overlay--damage { color: #ff8090; border: 1.5px solid #e76060; text-shadow: 0 1px 0 #000; }
+    .preview-overlay--heal   { color: #7ed957; border: 1.5px solid #5ecf8a; text-shadow: 0 1px 0 #000; }
+    .preview-overlay--buff   { color: #ffd47a; border: 1.5px solid #c4a35a; text-shadow: 0 1px 0 #000; font-size: clamp(0.55rem, 0.95vw, 0.78rem); }
+    .preview-overlay--status { color: #ff80b0; border: 1.5px solid #c43264; text-shadow: 0 1px 0 #000; font-size: clamp(0.55rem, 0.95vw, 0.78rem); }
+
     /* Status badges on portrait */
     .status-badges {
       position: absolute; top: 2px; left: 2px;

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -2189,6 +2189,8 @@ function setHandFocusByIndex(idx) {
     s.classList.remove("card-slot--focused", "card-peek--right");
     s.style.setProperty("--peek-lift", "0px");
   });
+  // Card preview cleanup
+  clearCardPreview();
   if (idx >= 0 && idx < slots.length && slots[idx] && !slots[idx].classList.contains("card-slot--disabled")) {
     handFocusedIdx = idx;
     const slot = slots[idx];
@@ -2209,8 +2211,125 @@ function setHandFocusByIndex(idx) {
       const lift = Math.max(0, rect.bottom - (viewH - 8));
       slot.style.setProperty("--peek-lift", lift + "px");
     });
+    // SPEC-006 UX: フォーカスされたカードのターゲットを portrait 上に視覚予告
+    const card = combat?.hand?.[idx];
+    if (card) setCardPreview(card);
   } else {
     handFocusedIdx = -1;
+  }
+}
+
+// ─── SPEC-006 UX: カード hover 時のターゲット preview ──────────────────
+// effects[].target を解決し、対象 portrait に枠ハイライト + 予測値オーバーレイを表示。
+// 計算は battle-mch.js のヘルパを流用 (実プレイ時と同じ式の中央値 = expected)
+
+function clearCardPreview() {
+  document.querySelectorAll(".preview-target-damage, .preview-target-heal, .preview-target-buff, .preview-target-status")
+    .forEach(el => el.classList.remove(
+      "preview-target-damage", "preview-target-heal", "preview-target-buff", "preview-target-status"
+    ));
+  document.querySelectorAll(".preview-overlay").forEach(el => el.remove());
+}
+
+/** 効果テキストを大まかに分類 (damage / heal / buff / status / unknown) */
+function classifyEffectKind(text) {
+  if (!text) return null;
+  const t = String(text);
+  if (/ダメ|ダメージ/.test(t)) return "damage";
+  if (/回復|HP\s*[+＋]/.test(t)) return "heal";
+  if (/毒|出血|脆弱|バインド/.test(t)) return "status";
+  if (/[+＋\-]/.test(t)) return "buff";
+  return null;
+}
+
+/** "50%" / "50-60%" を [lo, hi] に分解 (avg を使う) */
+function parsePercentRange(text) {
+  const m = String(text || "").match(/(\d+)(?:[-〜](\d+))?%/);
+  if (!m) return null;
+  const lo = parseInt(m[1], 10);
+  const hi = m[2] ? parseInt(m[2], 10) : lo;
+  return [lo, hi];
+}
+
+/** 予測ダメ計算 (caster の PHY/INT × 中央値 % × target の cut 後) */
+function predictEffectDamage(card, effect, caster, target) {
+  if (!caster || !target) return 0;
+  const range = parsePercentRange(effect.text);
+  if (!range) return 0;
+  const avg = (range[0] + range[1]) / 2;
+  // PHY か INT 判定: text 内に "INT" あれば INT、それ以外は skillIcon ベース or PHY
+  const isInt = /INT|int/.test(effect.text || "") || /int/i.test(card.skillIcon || "");
+  if (isInt) {
+    const cut = cutRateFromInt(target.int ?? 0);
+    return phyIntDamageAfterCut(caster.int ?? 0, avg, cut);
+  }
+  const cut = cutRateFromPhy(target.phy ?? 0);
+  return phyIntDamageAfterCut(caster.phy ?? 0, avg, cut);
+}
+
+/** 予測回復計算 */
+function predictEffectHeal(effect, caster) {
+  if (!caster) return 0;
+  const range = parsePercentRange(effect.text);
+  if (range) {
+    const avg = (range[0] + range[1]) / 2;
+    const coef = healingCoefficientIntCaster(caster.int ?? 0, caster.phy ?? 0);
+    return Math.max(0, Math.floor((coef * avg) / 100));
+  }
+  // 「+N 回復」のような実数指定
+  const r = String(effect.text || "").match(/[+＋](\d+)/);
+  return r ? parseInt(r[1], 10) : 0;
+}
+
+/** カード focus 時に対象 portrait へ視覚予告を貼る */
+function setCardPreview(card) {
+  if (!combat || !card) return;
+  const caster = resolveCaster(card.caster, combat);
+  if (!caster) return;
+
+  for (const effect of (card.effects || [])) {
+    const kind = classifyEffectKind(effect.text);
+    if (!kind) continue;
+    const targets = resolveTargets(effect.target, caster, combat);
+    if (!targets || targets.length === 0) continue;
+
+    for (const tgt of targets) {
+      if (!tgt || tgt.alive === false) continue;
+      const side = (tgt.side === "enemy") ? "enemy" : "player";
+      const portraitWrap = resolveUnitPortraitWrap(side, tgt);
+      if (!portraitWrap) continue;
+
+      // フレームハイライト
+      const cls = kind === "damage" ? "preview-target-damage"
+                : kind === "status" ? "preview-target-status"
+                : kind === "heal"   ? "preview-target-heal"
+                                    : "preview-target-buff";
+      portraitWrap.classList.add(cls);
+
+      // 予測値オーバーレイ
+      let overlayText = null;
+      let overlayClass = null;
+      if (kind === "damage") {
+        const dmg = predictEffectDamage(card, effect, caster, tgt);
+        if (dmg > 0) { overlayText = `-${dmg}`; overlayClass = "preview-overlay--damage"; }
+      } else if (kind === "heal") {
+        const amt = predictEffectHeal(effect, caster);
+        if (amt > 0) { overlayText = `+${amt}`; overlayClass = "preview-overlay--heal"; }
+      } else if (kind === "status") {
+        // 「毒 ×2」のような文字をそのまま簡略表示
+        overlayText = String(effect.text).replace(/\s+/g, "");
+        overlayClass = "preview-overlay--status";
+      } else if (kind === "buff") {
+        overlayText = String(effect.text).replace(/\s+/g, "");
+        overlayClass = "preview-overlay--buff";
+      }
+      if (overlayText) {
+        const ov = document.createElement("div");
+        ov.className = `preview-overlay ${overlayClass}`;
+        ov.textContent = overlayText;
+        portraitWrap.appendChild(ov);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

ユーザー要望: カード選択中に対象のヒーロー/エネミーと HP/パラメータへの変化が**直感的に**わかるよう、フレームハイライト + 予測値オーバーレイを追加。

## Visual Result

カードを focus すると:
- **攻撃カード**: 対象敵 portrait に **赤枠 + pulse glow + "-N" ダメ値** オーバーレイ
- **回復カード**: 対象ヒーロー portrait に **緑枠 + pulse + "+N" 回復値** オーバーレイ
- **バフカード**: 対象ヒーロー portrait に **金枠 + "PHY+N" "ガード+N"** badge
- **状態異常カード**: 対象敵 portrait に **紫枠 + "毒×N"** badge

## Changes

### `prototype/js/main.js`
- `setHandFocusByIndex` 前後で `setCardPreview(card)` / `clearCardPreview()` 呼出
- `setCardPreview(card)`:
  - `card.effects` 各 entry の target を `resolveTargets` で確定
  - `effect.text` を `classifyEffectKind` で damage / heal / buff / status に分類
  - 対象 portrait に `preview-target-*` class 付与 (CSS で枠ハイライト + glow)
  - damage/heal は 予測値計算 → `-N` / `+N` を overlay 表示
  - buff/status は effect text を簡略表示
- 計算ヘルパ:
  - `parsePercentRange("50-60%")` → `[50, 60]` 中央値で予測
  - `predictEffectDamage`: caster.phy/int × avg% × target cut (battle-mch.js と同式)
  - `predictEffectHeal`: healingCoefficientIntCaster × avg%

### `prototype/index.html`
- `.combatant-portrait-wrap.preview-target-{damage|status|heal|buff}`:
  - outline 3px (赤/紫/緑/金) + box-shadow glow
  - damage / heal は pulse animation で目立たせる
- `.preview-overlay` (portrait 上の予測値):
  - 上部中央に絶対配置、半透明黒背景 + カラー枠
  - フォントサイズは clamp() で responsive

## カード focus 例

| カード | caster | preview |
|---|---|---|
| ノービスブレード | foremost | 敵先頭に **赤枠 + "-7"** |
| ノービスペン | foremost | 自身に **緑枠 + "+20"** |
| ノービスアーマー | foremost | 自身に **金枠 + "PHY+2"** + **"ガード+7"** |
| ウィズダムスクロール (caster=highest_int) | highest_int | 敵先頭に **赤枠 + INT damage 値** + **"毒×2"** badge |

## Test plan
- [ ] 攻撃カードを focus すると敵先頭が赤枠 + ダメージ値が出る
- [ ] 回復カードを focus すると自身が緑枠 + 回復値が出る
- [ ] バフカードを focus すると自身が金枠 + 効果バッジが出る
- [ ] caster=front のカードで前衛死亡時、focus しても (もしくは grayed-out で) preview 出ない
- [ ] caster=highest_int のカードで focus、INT 最高ヒーローが caster として認識され、その INT 値で予測ダメが計算される
- [ ] focus 解除でハイライトが完全クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)