### PR TITLE
balance(passive): trigger 別バランス倍率を導入 (β1)

### DIFF
--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -82,6 +82,7 @@ import {
   applyPassiveTriggerAsync,
   checkPassiveThresholds,
   getRegisteredPassive,
+  multiplyPassiveDescription,
 } from "./passive-runtime.js";
 import { SAMPLE_PASSIVES } from "./passives-sample.js";
 import { PASSIVES } from "./passives-generated.js";
@@ -6822,7 +6823,11 @@ function togglePassivePopup() {
   }
   const heroName   = LEADER.nameJa        || "—";
   const skillName  = LEADER.passiveName   || "—";
-  const skillDesc  = LEADER.passiveDesc   || "—";
+  // β1: trigger 別倍率を効果数値に反映した文言で表示
+  const rawDesc    = LEADER.passiveDesc   || "—";
+  const skillDesc  = LEADER.passiveKey
+    ? multiplyPassiveDescription(LEADER.passiveKey, rawDesc)
+    : rawDesc;
   popup.innerHTML =
     `<div class="pp-hero-name">${heroName}</div>` +
     `<div class="pp-skill-name">【${skillName}】</div>` +
@@ -7369,7 +7374,11 @@ function renderHeroSelect() {
       html += `<span>INT ${hero.baseInt}</span>`;
       html += `<span>AGI ${hero.baseAgi}</span>`;
       html += `</div>`;
-      html += `<div class="hs-passive"><span class="hs-passive-name">【${hero.passiveName || '—'}】</span>${hero.passiveDesc}</div>`;
+      // β1: trigger 別倍率を効果数値に反映した文言で表示
+      const heroPassiveDesc = hero.passiveKey
+        ? multiplyPassiveDescription(hero.passiveKey, hero.passiveDesc)
+        : hero.passiveDesc;
+      html += `<div class="hs-passive"><span class="hs-passive-name">【${hero.passiveName || '—'}】</span>${heroPassiveDesc}</div>`;
       html += `</div></div>`;
     });
     html += '</div>';

--- a/prototype/js/passive-runtime.js
+++ b/prototype/js/passive-runtime.js
@@ -98,6 +98,100 @@ function multiplierFor(triggerKind) {
   return TRIGGER_BUFF_MULTIPLIER[triggerKind] ?? 1;
 }
 
+// ─── 説明文 (passiveDesc) の数値倍率書き換え ──────────────────────
+// "戦闘開始時に発動・敵にPHYの40%ダメージ" を mult=3 で書き換えると
+// "戦闘開始時に発動・敵にPHYの120%ダメージ" になる。
+// trigger 句 (HP%未満 / 確率% / 1回だけ等) は触らず、effects 部のみ
+// 正規表現置換。stacks 系は最小 1 で四捨五入。
+function rewriteEffectNumbers(body, mult) {
+  if (!body || mult === 1) return body;
+  const round = (n) => Math.round(n);
+  const stack = (n) => Math.max(1, Math.round(n));
+
+  // PHY/INT N% ダメージ — 接頭辞 (敵に / 先頭の敵に / 中衛の敵に等) は match 範囲外。
+  // 「敵に」を起点にすると「先頭の敵に...」も同じ regex が拾うので、別 regex で
+  // ダブルマッチさせない (旧版でこのバグあり、self.tookDamage の zhang が 80% 化していた)
+  body = body.replace(
+    /(敵に(?:PHY|INT)(?:の)?)(\d+)(?:[~〜](\d+))?(%(?:追加)?ダメージ)/g,
+    (_full, p1, lo, hi, p4) => hi
+      ? `${p1}${round(+lo * mult)}〜${round(+hi * mult)}${p4}`
+      : `${p1}${round(+lo * mult)}${p4}`,
+  );
+  // 自身のPHY/INT/AGI を Nアップ
+  body = body.replace(
+    /(自身の(?:PHY|INT|AGI)を)(\d+)(アップ)/g,
+    (_, p1, n, p3) => `${p1}${round(+n * mult)}${p3}`,
+  );
+  // 自身のPHY/INT/AGI+N
+  body = body.replace(
+    /(自身の(?:PHY|INT|AGI))\+(\d+)/g,
+    (_, p1, n) => `${p1}+${round(+n * mult)}`,
+  );
+  // 短縮形: " INT +3" / "PHY +5" (自身の prefix 抜け、e.g. doyle "INT +3")
+  body = body.replace(
+    /(^|[\s・／])(PHY|INT|AGI)\s*\+\s*(\d+)/g,
+    (_, sep, stat, n) => `${sep}${stat} +${round(+n * mult)}`,
+  );
+  // 自身のXを最大YのN%アップ
+  body = body.replace(
+    /(自身の(?:PHY|INT|AGI)を最大(?:PHY|INT|AGI)の)(\d+)(%アップ)/g,
+    (_, p1, n, p3) => `${p1}${round(+n * mult)}${p3}`,
+  );
+  // PHYとINTを互いの値のN%アップ
+  body = body.replace(
+    /(PHYとINTを互いの値の)(\d+)(%アップ)/g,
+    (_, p1, n, p3) => `${p1}${round(+n * mult)}${p3}`,
+  );
+  // 敵のXをN%ダウン
+  body = body.replace(
+    /(敵の(?:PHY|INT|AGI)を)(\d+)(%ダウン)/g,
+    (_, p1, n, p3) => `${p1}${round(+n * mult)}${p3}`,
+  );
+  // 敵のX-N
+  body = body.replace(
+    /(敵の(?:PHY|INT|AGI))-(\d+)/g,
+    (_, p1, n) => `${p1}-${round(+n * mult)}`,
+  );
+  // 敵に毒/出血 ×N 付与 (× は ASCII x も許容)
+  body = body.replace(
+    /(敵に(?:毒|出血)[×x])(\d+)(付与)/g,
+    (_, p1, n, p3) => `${p1}${stack(+n * mult)}${p3}`,
+  );
+  // ガード/シールド +N
+  body = body.replace(
+    /((?:ガード|シールド))\+(\d+)/g,
+    (_, p1, n) => `${p1}+${round(+n * mult)}`,
+  );
+  // HPを最大HPのN%回復
+  body = body.replace(
+    /(HPを最大HPの)(\d+)(%回復)/g,
+    (_, p1, n, p3) => `${p1}${round(+n * mult)}${p3}`,
+  );
+  // HPを回復係数のN(〜N)%回復
+  body = body.replace(
+    /(HPを回復係数の)(\d+)(?:[~〜](\d+))?(%回復)/g,
+    (_, p1, lo, hi, p4) => hi
+      ? `${p1}${round(+lo * mult)}〜${round(+hi * mult)}${p4}`
+      : `${p1}${round(+lo * mult)}${p4}`,
+  );
+  return body;
+}
+
+/** 説明文 (passiveDesc) の効果数値を trigger 倍率で書き換える。
+ *  passiveKey 未登録 / 倍率 1 の場合は元 desc をそのまま返す。 */
+export function multiplyPassiveDescription(passiveKey, desc) {
+  if (!desc) return desc;
+  const def = getRegisteredPassive(passiveKey);
+  if (!def) return desc;
+  const mult = multiplierFor(def.trigger);
+  if (mult === 1) return desc;
+  // 「<trigger 句>に発動・<body>」を分離して body のみ書き換え
+  const m = desc.match(/^(.+?に発動・)(.+)$/);
+  if (m) return m[1] + rewriteEffectNumbers(m[2], mult);
+  // 「に発動・」が無い場合は全体を body と見なす
+  return rewriteEffectNumbers(desc, mult);
+}
+
 // ─── trigger ごとのフィルタ ─────────────────────────────────────────
 
 /** trigger と現在の戦闘状態を見て発動可否を判定 */

--- a/prototype/js/passive-runtime.js
+++ b/prototype/js/passive-runtime.js
@@ -57,6 +57,47 @@ export function _debugListPassivesWithNotes() {
 // self.hpBelow / party.hpBelow / enemy.hpBelow / self.statRatioAbove /
 // enemy.cardPlayed
 
+// ─── trigger 別バランス倍率 (β1 仕様) ─────────────────────────────
+// self.cardPlayed は毎カードごと発動するためそのまま 1x。
+// 発動機会の少ない trigger は元 DB 数値だけでは弱すぎるので倍率で底上げ。
+// 倍率は damage coef / heal coef / buffStat value / addGuard|addShield /
+// applyStatus stacks / drawCards / addEnergy 等の数値フィールドに乗る。
+// (revive.coef.hpRatio や閾値系の threshold には適用しない)
+export const TRIGGER_BUFF_MULTIPLIER = {
+  "combat.started":      3,  // バトル開始時 (1 戦闘 1 回 限定がほとんど)
+  "self.tookDamage":     2,  // 被ダメージ後 (確率発動が多い)
+  "self.hpBelow":        4,  // HP 低下トリガ
+  "party.hpBelow":       4,
+  "enemy.hpBelow":       4,
+  "self.statRatioAbove": 4,  // ステ比トリガ (パラメータ低下系の代替分類)
+  "self.died":           5,  // 死亡時 (1 戦闘 1 回)
+  "self.cardPlayed":     1,  // カード使用後 (発動機会多 → そのまま)
+  "enemy.cardPlayed":    1,  // 敵カード使用後 (発動機会多)
+};
+
+/** effect の数値フィールドを倍率適用 (元 effect は破壊しない) */
+function multiplyEffect(effect, mult) {
+  if (!effect || mult === 1 || !Number.isFinite(mult)) return effect;
+  const out = { ...effect };
+  // revive はバランスではなく機構なので倍率適用しない
+  if (out.action === "revive") return out;
+  if (out.coef && typeof out.coef === "object") {
+    const newCoef = {};
+    for (const [k, v] of Object.entries(out.coef)) {
+      newCoef[k] = (typeof v === "number") ? v * mult : v;
+    }
+    out.coef = newCoef;
+  }
+  if (typeof out.value === "number") out.value = out.value * mult;
+  if (typeof out.pct === "number") out.pct = out.pct * mult;
+  if (typeof out.stacks === "number") out.stacks = Math.max(1, Math.round(out.stacks * mult));
+  return out;
+}
+
+function multiplierFor(triggerKind) {
+  return TRIGGER_BUFF_MULTIPLIER[triggerKind] ?? 1;
+}
+
 // ─── trigger ごとのフィルタ ─────────────────────────────────────────
 
 /** trigger と現在の戦闘状態を見て発動可否を判定 */
@@ -157,12 +198,13 @@ export function applyPassiveTrigger(s, kind, ctx = {}) {
     if (kind === "self.died" && ctx.hero && hero !== ctx.hero) continue;
     if (!shouldFire(s, hero, def, ctx)) continue;
 
-    // 発動: cutin → effects 順次実行
+    // 発動: cutin → effects 順次実行 (trigger 別倍率を適用)
     if (def.cutinSkillName && _effectHandlers?.showCutin) {
       _effectHandlers.showCutin(hero, def.cutinSkillName);
     }
+    const mult = multiplierFor(def.trigger);
     for (const effect of def.effects || []) {
-      applyPassiveEffect(s, hero, effect);
+      applyPassiveEffect(s, hero, multiplyEffect(effect, mult));
     }
     markTriggered(hero, def);
   }
@@ -193,9 +235,10 @@ export async function applyPassiveTriggerAsync(s, kind, ctx = {}) {
         _effectHandlers.showCutin(hero, def.cutinSkillName);
       }
     }
-    // 2. effects 順次実行
+    // 2. effects 順次実行 (trigger 別倍率を適用)
+    const mult = multiplierFor(def.trigger);
     for (const effect of def.effects || []) {
-      applyPassiveEffect(s, hero, effect);
+      applyPassiveEffect(s, hero, multiplyEffect(effect, mult));
     }
     markTriggered(hero, def);
   }
@@ -213,8 +256,9 @@ export function checkPassiveThresholds(s, hero) {
   if (def.cutinSkillName && _effectHandlers?.showCutin) {
     _effectHandlers.showCutin(hero, def.cutinSkillName);
   }
+  const mult = multiplierFor(def.trigger);
   for (const effect of def.effects || []) {
-    applyPassiveEffect(s, hero, effect);
+    applyPassiveEffect(s, hero, multiplyEffect(effect, mult));
   }
   markTriggered(hero, def);
 }


### PR DESCRIPTION
## Summary

ヒーローパッシブの効果を trigger 別に倍率調整。`self.cardPlayed` (毎カード発動するもの) はそのまま、それ以外は発動機会が少なく元 DB 数値だけでは弱すぎたので底上げ。

| Trigger | 倍率 | 主な対象 |
|---|---|---|
| `combat.started` | **3x** | バトル開始時 (1 戦闘 1 回) |
| `self.tookDamage` | **2x** | 被ダメージ後 (確率発動が多い) |
| `self.hpBelow` / `party.hpBelow` / `enemy.hpBelow` | **4x** | HP 低下トリガ |
| `self.statRatioAbove` | **4x** | パラメータ低下系の代替分類 |
| `self.died` | **5x** | 死亡時 (1 戦闘 1 回) |
| `self.cardPlayed` / `enemy.cardPlayed` | 1x (変更なし) | カード使用後 (発動機会多) |

## 倍率が乗る効果フィールド

- `damage.coef.{phy,int}` (ダメージ係数)
- `heal.coef.{int,hp,hpRatio}` (回復係数)
- `buffStat.value` (PHY/INT/AGI 加算)
- `buffStatFromOther.pct` (別ステ参照バフの割合)
- `buffStatPct.pct` (パーセント加減)
- `addGuard.value` / `addShield.value`
- `applyStatus.stacks` (毒/出血スタック数)
- `drawCards.value` / `addEnergy.value`

**非適用** (機構/閾値):
- `revive.coef.hpRatio` (致死時生存は機構なので 1HP 復活のまま)
- `threshold` (発動条件は変更しない)

## 実装

`passive-runtime.js` に以下を追加:
- `TRIGGER_BUFF_MULTIPLIER` 定数 (export 済み、QA でも参照可能)
- `multiplyEffect(effect, mult)` ヘルパ (元 effect は破壊しない)
- `applyPassiveTrigger` / `applyPassiveTriggerAsync` / `checkPassiveThresholds` の 3 dispatch 関数で `multiplierFor(def.trigger)` を適用

## 適用後サンプル

| ヒーロー | trigger | 元 | 適用後 |
|---|---|---|---|
| giraffa | combat.started | PHY 40% ダメ | **PHY 120% ダメ** |
| sullivan | combat.started | PHY +5 | **PHY +15** |
| inoh | combat.started | 最大 AGI の 30% を INT へ | **90% を INT へ** |
| seton | combat.started | INT 40% + 出血×1 | **INT 120% + 出血×3** |
| hercules | combat.started | 敵 INT -30% | **敵 INT -90%** (実質ゼロ化) |
| doyle | self.hpBelow | INT +3 | **INT +12** |
| zhang | self.tookDamage | PHY 20% カウンター | **PHY 40% カウンター** |
| schubert | self.died | 1 HP 復活 | 変更なし (revive 非適用) |
| kaihime | self.cardPlayed | PHY 50% ダメ | 変更なし (1x) |

## Test plan

- [ ] 1010 (giraffa) を前衛にして戦闘開始 → 敵 HP がガッツリ減ること
- [ ] 1008 (sullivan) を前衛にして戦闘開始 → PHY +15 されること
- [ ] 1006 (pythagoras) を前衛にして戦闘開始 → PHY/INT がそれぞれ互いの 60% 上昇
- [ ] 1009 (hercules) を前衛にして戦闘開始 → 敵 INT が 1 まで激減
- [ ] doyle を HP 70% 未満にして INT +12 を確認
- [ ] zhang が被弾時に 40% カウンターを確認 (元 20% から)
- [ ] kaihime のカード発動効果は変わらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)