### PR TITLE
fix(ranking): 戻るボタンで遷移元画面に復帰するよう修正

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -2769,7 +2769,7 @@
         <div class="rk-controls">
           <select data-rk-filter aria-label="レギュレーションでフィルタ"></select>
           <button type="button" class="action" data-rk-refresh>更新</button>
-          <button type="button" class="action" data-rk-back>← タイトルへ</button>
+          <button type="button" class="action" data-rk-back>← 戻る</button>
         </div>
       </div>
       <div data-rk-list>

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -7074,8 +7074,12 @@ function openRankingSubmitModal() {
   confirmBtn.addEventListener("click", onConfirm);
 }
 
+/** ランキング画面を開く前の画面を覚えておき、戻るボタンで復帰するために保持 */
+let _rankingReturnView = null;
+
 /** ランキング画面を開く */
 async function openRankingView() {
+  if (view !== "ranking") _rankingReturnView = view;
   showView("ranking");
   await renderRankingView();
 }
@@ -7138,7 +7142,11 @@ async function renderRankingView() {
       filterEl.addEventListener("change", () => renderRankingView());
     }
     el.querySelector("[data-rk-refresh]")?.addEventListener("click", () => renderRankingView());
-    el.querySelector("[data-rk-back]")?.addEventListener("click", () => showView("title"));
+    el.querySelector("[data-rk-back]")?.addEventListener("click", () => {
+      const target = _rankingReturnView || "map";
+      _rankingReturnView = null;
+      showView(target);
+    });
     el.querySelector("[data-rk-save-apiurl]")?.addEventListener("click", () => {
       const input = el.querySelector("[data-rk-apiurl]");
       if (!input) return;


### PR DESCRIPTION
## Summary
- ヘッダーのランキングボタンから開いたランキング画面の戻るボタンが、どこから開いても強制的にタイトル画面に飛んでしまう問題を修正
- ランキング画面を開く直前の view 名を保持し、戻るボタンで元の画面（map / combat / shop / nodeSelect / heroSelect 等）に復帰
- ボタンラベルを「← タイトルへ」→「← 戻る」に変更

## 変更ファイル
- prototype/index.html: ボタンラベル変更
- prototype/js/main.js: \`_rankingReturnView\` で遷移元 view を保持し、戻るボタンで復帰

## Test plan
- [ ] map 画面 → ランキング → 戻る で map に戻ること
- [ ] combat 画面 → ランキング → 戻る で combat に戻ること（戦闘状態が保持されていること）
- [ ] shop / nodeSelect / heroSelect / regulationSelect から開いた場合も同様に元の画面に戻ること
- [ ] フォールバックとして遷移元不明な場合は map に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)