### PR TITLE
feat(sheet-sync P1): heroes / ll-extensions の Spreadsheet 同期 GAS

### DIFF
--- a/tools/gas-sheet-sync/README.md
+++ b/tools/gas-sheet-sync/README.md
@@ -1,0 +1,132 @@
+# GAS Sheet ↔ JSON 同期 (P1: heroes / ll-extensions)
+
+`prototype/data/heroes.json` と `prototype/data/ll-extensions.json` を Google Spreadsheet と同期する Container-bound GAS スクリプト一式。テスターは Spreadsheet でパラメータを編集 → ボタンで GitHub PR 作成、というフローで素早くバランス調整ができる。
+
+## 機能
+
+- **Pull (誰でも実行可)**: GitHub main の最新 JSON を取得し、Spreadsheet に流し込む
+- **Push (`bearko.miyamoto@gmail.com` のみ実行可)**: Spreadsheet の内容を JSON に再構築し、新ブランチを切って PR を作成
+- `rarity` 列はプルダウン (common / uncommon / rare / epic / legendary)
+- `_meta` 隠しシートに pull/push の SHA・実行ユーザを記録 → スプレッドシートが古いまま push しないよう警告
+
+## 対象 JSON
+
+| sheet 名 | path |
+|---|---|
+| `heroes` | `prototype/data/heroes.json` (210 件) |
+| `ll-extensions` | `prototype/data/ll-extensions.json` (6 件) |
+
+`enemies.json` / `bosses.json` は P2 / P3 で対応 (intentRota / phases のネストがあるため別シート分離設計が必要)。
+
+---
+
+## セットアップ手順 (初回 1 回のみ)
+
+### 1. Spreadsheet 作成
+
+1. https://sheets.new で新規スプレッドシートを作成
+2. 名前を `MCT バランス調整シート` 等に変更
+
+### 2. Apps Script を開く
+
+1. メニュー [拡張機能] → [Apps Script]
+2. プロジェクト名を `MCT-sheet-sync` 等に変更
+
+### 3. ソース貼り付け
+
+このディレクトリの `.gs` ファイルを Apps Script エディタにそれぞれ作成・貼り付ける:
+
+| ファイル名 | 種類 | 内容 |
+|---|---|---|
+| `menu.gs` | スクリプトファイル | onOpen + メニュー登録 |
+| `pull.gs` | スクリプトファイル | Pull 処理 |
+| `push.gs` | スクリプトファイル | Push 処理 |
+| `github.gs` | スクリプトファイル | GitHub API ヘルパ |
+| `schema.gs` | スクリプトファイル | 列定義 + dropdown |
+| `appsscript.json` | (隠しマニフェスト) | OAuth scope 設定 |
+
+`appsscript.json` を編集するには Apps Script の [プロジェクトの設定] で「`appsscript.json` マニフェスト ファイルをエディタで表示する」にチェック。
+
+### 4. Script Properties を設定
+
+Apps Script エディタ左メニュー [プロジェクトの設定] → 一番下の [スクリプト プロパティ] → [スクリプト プロパティを追加] で以下 5 件を追加:
+
+| プロパティ | 値 |
+|---|---|
+| `GITHUB_PAT` | (下記で発行する PAT) |
+| `GITHUB_OWNER` | `bearko` |
+| `GITHUB_REPO` | `mycryptotactics` |
+| `GITHUB_BASE_BRANCH` | `main` |
+| `PUSH_ALLOWED_EMAIL` | `bearko.miyamoto@gmail.com` |
+
+### 5. GitHub PAT を発行
+
+1. https://github.com/settings/personal-access-tokens/new (fine-grained PAT)
+2. **Token name**: `mct-sheet-sync` 等
+3. **Resource owner**: bearko
+4. **Repository access**: `Only select repositories` → `bearko/mycryptotactics` のみ
+5. **Permissions** → `Repository permissions`:
+   - **Contents**: Read and write
+   - **Pull requests**: Read and write
+   - (Metadata: Read — 自動で付く)
+6. **Generate token** → 生成された `github_pat_xxxx` をコピー → 上記 `GITHUB_PAT` プロパティに貼り付け
+
+### 6. 動作確認
+
+1. Spreadsheet をリロード (タブを閉じて開き直す)
+2. メニュー [データ同期] が表示されることを確認 (`onOpen` 動作)
+3. [データ同期] → [Script Properties をチェック] で 5 件すべて設定済みか確認
+4. [データ同期] → [GitHub から最新を取得 (Pull)] を実行
+   - 初回は GAS の権限要求ダイアログが出る → 許可
+   - 完了後、`heroes` / `ll-extensions` / `_meta` シートが作られていれば成功
+
+### 7. テスター招待
+
+- スプレッドシートを共有 (テスターのメールに [編集者] 権限)
+- テスターは Pull / Push どちらのメニューも見えるが、Push は `PUSH_ALLOWED_EMAIL` チェックで弾かれる
+- Push したい時は `bearko.miyamoto@gmail.com` でログインして実行
+
+---
+
+## 使い方 (運用フロー)
+
+### A. テスターがバランスを試したい時
+
+1. [データ同期] → [GitHub から最新を取得 (Pull)] でリポの最新を取り込む
+2. シート上で値を編集 (rarity はプルダウン、それ以外は自由入力)
+3. テスターは bearko に「これで PR お願い」と通知
+4. bearko が同じシートを開いて [データ同期] → [Spreadsheet を GitHub に PR (Push)] を実行
+5. 確認ダイアログで変更内容を確認 → Yes
+6. PR URL がアラートで出る → ブラウザで確認 → 通常通りマージ
+
+### B. main で別途編集が入った時
+
+- pull した SHA と現在 main HEAD のズレを Push 時に検出して警告
+- ズレている場合は一度 Pull し直して、シート編集を再実行
+
+### C. シート編集中にエラーが出た時
+
+- 行/列を間違って削除しても Pull で復元可能
+- ただし他人が編集中に Pull すると上書きされるので注意 (Push 同様、運用ルールでカバー)
+
+---
+
+## トラブルシューティング
+
+| 症状 | 原因 / 対処 |
+|---|---|
+| 「Script Properties が未設定です」 | 上記手順 4 で 5 件全部設定したか確認 |
+| 「Push 権限がありません」 | 実行ユーザが `PUSH_ALLOWED_EMAIL` と一致しているか / 大文字小文字含めて |
+| 「GitHub API 401」 | PAT の有効期限切れ / 権限不足 / repo が変わっていないか |
+| 「GitHub API 422 (branch already exists)」 | 同一秒で 2 回 push した。少し待ってもう一度 |
+| Pull したが日本語が文字化け | スプレッドシートのロケールを「日本」に設定 |
+| dropdown が出ない | Pull すると自動で再設定される |
+
+---
+
+## 既知の制約 (P1)
+
+- **配列形式の JSON のみ対応** — heroes/ll-extensions はトップレベル `[...]`。enemies/bosses (object形式 + 入れ子) は P2/P3 で対応
+- **passiveDesc 等のテキスト列は自由入力** — runtime の `multiplyPassiveDescription` regex に hit する形式 (例: 「戦闘開始時に発動・敵にPHYのN%ダメージ」) を保つ必要あり
+- **effectKey は文字列キー** — ll-extensions は `effectKey` がハードコード dispatch なので、新しいキーを書いても JS 実装側に対応がないと動かない (P4 で declarative 化予定)
+- **同時編集の競合は手動運用** — 複数人が同時に Push するとブランチ名衝突 (タイムスタンプベースなので秒未満では衝突しうる)

--- a/tools/gas-sheet-sync/appsscript.json
+++ b/tools/gas-sheet-sync/appsscript.json
@@ -1,0 +1,11 @@
+{
+  "timeZone": "Asia/Tokyo",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/userinfo.email"
+  ]
+}

--- a/tools/gas-sheet-sync/github.gs
+++ b/tools/gas-sheet-sync/github.gs
@@ -1,0 +1,125 @@
+/**
+ * github.gs — GitHub API 共通ヘルパ
+ *
+ * PropertiesService から PAT / repo 情報を読み出し、低レベル API を提供。
+ *
+ * 必要な ScriptProperties:
+ *   GITHUB_PAT      … fine-grained PAT (repo 権限: Contents Read/Write + PR Read/Write)
+ *   GITHUB_OWNER    … "bearko"
+ *   GITHUB_REPO     … "mycryptotactics"
+ *   GITHUB_BASE_BRANCH … "main"
+ *   PUSH_ALLOWED_EMAIL … "bearko.miyamoto@gmail.com" (Push 実行を許可するユーザのメール)
+ */
+
+const GH_API = "https://api.github.com";
+
+function ghProps_() {
+  const p = PropertiesService.getScriptProperties();
+  const required = ["GITHUB_PAT", "GITHUB_OWNER", "GITHUB_REPO", "GITHUB_BASE_BRANCH", "PUSH_ALLOWED_EMAIL"];
+  const missing = required.filter(k => !p.getProperty(k));
+  if (missing.length > 0) {
+    throw new Error("Script Properties が未設定です: " + missing.join(", ") + "\n[ファイル] → [プロジェクトのプロパティ] → [スクリプトのプロパティ] で設定してください。");
+  }
+  return {
+    pat:    p.getProperty("GITHUB_PAT"),
+    owner:  p.getProperty("GITHUB_OWNER"),
+    repo:   p.getProperty("GITHUB_REPO"),
+    base:   p.getProperty("GITHUB_BASE_BRANCH"),
+    pushAllowedEmail: p.getProperty("PUSH_ALLOWED_EMAIL"),
+  };
+}
+
+/** Push 実行ユーザの権限チェック (bearko.miyamoto@gmail.com のみ許可) */
+function ghAssertPushAllowed_() {
+  const email = (Session.getActiveUser().getEmail() || "").toLowerCase();
+  const allowed = ghProps_().pushAllowedEmail.toLowerCase();
+  if (email !== allowed) {
+    throw new Error(
+      "Push 権限がありません。\n" +
+      "実行ユーザ: " + (email || "(取得不可)") + "\n" +
+      "許可ユーザ: " + allowed + "\n" +
+      "Pull (GitHub から最新を取得) は誰でも実行できます。"
+    );
+  }
+}
+
+/** GitHub API 呼び出し (認証付き) */
+function ghApi_(method, path, body) {
+  const props = ghProps_();
+  const opts = {
+    method: method,
+    headers: {
+      Authorization: "Bearer " + props.pat,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    muteHttpExceptions: true,
+    contentType: "application/json",
+  };
+  if (body) opts.payload = JSON.stringify(body);
+  const url = GH_API + path;
+  const res = UrlFetchApp.fetch(url, opts);
+  const code = res.getResponseCode();
+  const text = res.getContentText();
+  if (code >= 200 && code < 300) {
+    return text ? JSON.parse(text) : null;
+  }
+  throw new Error("GitHub API " + method + " " + path + " → " + code + "\n" + text);
+}
+
+/** raw.githubusercontent.com から JSON を取得 (認証不要、anonymous) */
+function ghFetchRawJson(path, ref) {
+  const props = ghProps_();
+  const url = "https://raw.githubusercontent.com/" + props.owner + "/" + props.repo + "/" + (ref || props.base) + "/" + path;
+  const res = UrlFetchApp.fetch(url, { muteHttpExceptions: true });
+  if (res.getResponseCode() !== 200) {
+    throw new Error("raw fetch failed: " + url + " (" + res.getResponseCode() + ")");
+  }
+  return JSON.parse(res.getContentText());
+}
+
+/** 指定 ref (branch) の HEAD commit SHA を取得 */
+function ghGetRefSha(ref) {
+  const props = ghProps_();
+  const r = ghApi_("GET", "/repos/" + props.owner + "/" + props.repo + "/git/refs/heads/" + ref);
+  return r.object.sha;
+}
+
+/** 新しいブランチを base branch から作成 */
+function ghCreateBranch(branchName, baseSha) {
+  const props = ghProps_();
+  return ghApi_("POST", "/repos/" + props.owner + "/" + props.repo + "/git/refs", {
+    ref: "refs/heads/" + branchName,
+    sha: baseSha,
+  });
+}
+
+/** 指定パスの現在の content + sha (file 上書きに必要) を取得 */
+function ghGetFile(path, ref) {
+  const props = ghProps_();
+  return ghApi_("GET", "/repos/" + props.owner + "/" + props.repo + "/contents/" + path + "?ref=" + ref);
+}
+
+/** ファイルを PUT (新規作成 or 上書き)
+ *  contentStr: 平文 (Base64 化は内部で実施) */
+function ghPutFile(path, branch, contentStr, message, currentSha) {
+  const props = ghProps_();
+  const body = {
+    message: message,
+    branch: branch,
+    content: Utilities.base64Encode(Utilities.newBlob(contentStr).getBytes()),
+  };
+  if (currentSha) body.sha = currentSha;
+  return ghApi_("PUT", "/repos/" + props.owner + "/" + props.repo + "/contents/" + path, body);
+}
+
+/** Pull Request 作成 */
+function ghCreatePullRequest(title, branch, base, body) {
+  const props = ghProps_();
+  return ghApi_("POST", "/repos/" + props.owner + "/" + props.repo + "/pulls", {
+    title: title,
+    head: branch,
+    base: base,
+    body: body || "",
+  });
+}

--- a/tools/gas-sheet-sync/menu.gs
+++ b/tools/gas-sheet-sync/menu.gs
@@ -1,0 +1,47 @@
+/**
+ * menu.gs — onOpen でカスタムメニューを追加
+ *
+ * Spreadsheet を開くたびに「データ同期」メニューが表示される。
+ */
+
+function onOpen() {
+  SpreadsheetApp.getUi()
+    .createMenu("データ同期")
+    .addItem("GitHub から最新を取得 (Pull)", "pullAllFromGitHub")
+    .addItem("Spreadsheet を GitHub に PR (Push)", "pushAllToGitHubAsPR")
+    .addSeparator()
+    .addItem("最終同期情報を表示", "showSyncStatus")
+    .addItem("Script Properties をチェック", "checkProperties")
+    .toRoot();
+}
+
+function showSyncStatus() {
+  const lines = [
+    "── 最終同期情報 ──",
+    "lastSyncedSha:    " + (getMetaValue_("lastSyncedSha") || "(未 pull)"),
+    "lastPullAt:       " + (getMetaValue_("lastPullAt")    || "—"),
+    "lastPullBy:       " + (getMetaValue_("lastPullBy")    || "—"),
+    "lastPushAt:       " + (getMetaValue_("lastPushAt")    || "—"),
+    "lastPushBy:       " + (getMetaValue_("lastPushBy")    || "—"),
+    "lastPushBranch:   " + (getMetaValue_("lastPushBranch")|| "—"),
+    "lastPushPr:       " + (getMetaValue_("lastPushPr")    || "—"),
+  ];
+  SpreadsheetApp.getUi().alert(lines.join("\n"));
+}
+
+function checkProperties() {
+  try {
+    const p = ghProps_();
+    SpreadsheetApp.getUi().alert(
+      "Script Properties OK\n" +
+      "owner: " + p.owner + "\n" +
+      "repo:  " + p.repo + "\n" +
+      "base:  " + p.base + "\n" +
+      "PAT:   " + (p.pat ? "(設定済み, " + p.pat.length + " chars)" : "(未設定)") + "\n" +
+      "PUSH_ALLOWED_EMAIL: " + p.pushAllowedEmail + "\n" +
+      "現在のユーザ:         " + (Session.getActiveUser().getEmail() || "(取得不可)")
+    );
+  } catch (e) {
+    SpreadsheetApp.getUi().alert(e.message);
+  }
+}

--- a/tools/gas-sheet-sync/pull.gs
+++ b/tools/gas-sheet-sync/pull.gs
@@ -1,0 +1,121 @@
+/**
+ * pull.gs — GitHub の最新 JSON を Spreadsheet に流し込み
+ *
+ * 公開リポなら raw URL から anonymous fetch (PAT 不要)。
+ * カスタムメニュー「データ同期」→「GitHub から最新を取得 (Pull)」で実行。
+ */
+
+/** メニュー: 全シート pull */
+function pullAllFromGitHub() {
+  const ui = SpreadsheetApp.getUi();
+  try {
+    const props = ghProps_();
+    const ref = props.base;
+    let total = 0;
+    for (const schema of ALL_SCHEMAS) {
+      const json = ghFetchRawJson(schema.jsonPath, ref);
+      const rows = jsonToRows_(json, schema);
+      writeSheet_(schema, rows);
+      total += rows.length;
+    }
+    // 同期 SHA をメモ
+    const headSha = ghGetRefSha(ref);
+    setMetaValue_("lastSyncedSha", headSha);
+    setMetaValue_("lastPullAt", new Date().toISOString());
+    setMetaValue_("lastPullBy", Session.getActiveUser().getEmail() || "(unknown)");
+    ui.alert("Pull 完了\n" + total + " 件を取得しました。\nbase ref: " + ref + "\nSHA: " + headSha.substring(0, 7));
+  } catch (e) {
+    ui.alert("Pull 失敗\n" + e.message);
+    throw e;
+  }
+}
+
+/** JSON データを 2 次元配列に変換
+ *  入力 JSON の形態 (array / object) は schema 側で吸収。
+ *  bosses/enemies は object[] でなく {id: {...}} 形式 (今回 P1 では未対応)。 */
+function jsonToRows_(json, schema) {
+  // P1 対象 (heroes / ll-extensions) は配列形式
+  let entries;
+  if (Array.isArray(json)) {
+    entries = json;
+  } else {
+    // 万一 object 形式 (id をキー) の場合は値を取り出し、id を 1 列目に noop で扱う想定
+    entries = Object.values(json);
+  }
+  return entries.map(item =>
+    schema.columns.map(col => displayValue_(item[col.name]))
+  );
+}
+
+/** シートに書き込み (header 行 + データ行) + dropdown 設定 */
+function writeSheet_(schema, rows) {
+  const ss = SpreadsheetApp.getActive();
+  let sheet = ss.getSheetByName(schema.sheetName);
+  if (!sheet) sheet = ss.insertSheet(schema.sheetName);
+
+  sheet.clear();
+  const headers = schema.columns.map(c => c.name);
+  sheet.getRange(1, 1, 1, headers.length).setValues([headers]).setFontWeight("bold").setBackground("#e8eaf6");
+  sheet.setFrozenRows(1);
+
+  if (rows.length > 0) {
+    sheet.getRange(2, 1, rows.length, headers.length).setValues(rows);
+  }
+
+  // dropdown
+  schema.columns.forEach((col, idx) => {
+    if (col.type !== "enum" || !col.options || col.options.length === 0) return;
+    const colIdx = idx + 1;
+    const range = sheet.getRange(2, colIdx, Math.max(rows.length, 100), 1);
+    const rule = SpreadsheetApp.newDataValidation()
+      .requireValueInList(col.options, true)
+      .setAllowInvalid(false)
+      .setHelpText("選択肢: " + col.options.join(" / "))
+      .build();
+    range.setDataValidation(rule);
+  });
+
+  // 列幅自動調整 (heroId 系は固定幅で十分)
+  for (let i = 1; i <= headers.length; i++) sheet.autoResizeColumn(i);
+  // passiveDesc 列が長い場合は折り返し
+  const descColIdx = schema.columns.findIndex(c => /Desc$|^desc$/.test(c.name));
+  if (descColIdx >= 0) {
+    sheet.getRange(1, descColIdx + 1, sheet.getMaxRows(), 1).setWrap(true);
+    sheet.setColumnWidth(descColIdx + 1, 480);
+  }
+}
+
+// ─── _meta シート ────────────────────────────────────────────────
+function getMetaSheet_() {
+  const ss = SpreadsheetApp.getActive();
+  let sheet = ss.getSheetByName(SHEET_META);
+  if (!sheet) {
+    sheet = ss.insertSheet(SHEET_META);
+    sheet.hideSheet();
+    sheet.getRange(1, 1, 1, 2).setValues([["key", "value"]]);
+    sheet.setFrozenRows(1);
+  }
+  return sheet;
+}
+
+function getMetaValue_(key) {
+  const sheet = getMetaSheet_();
+  const last = sheet.getLastRow();
+  if (last < 2) return null;
+  const data = sheet.getRange(2, 1, last - 1, 2).getValues();
+  for (const [k, v] of data) if (k === key) return v;
+  return null;
+}
+
+function setMetaValue_(key, value) {
+  const sheet = getMetaSheet_();
+  const last = sheet.getLastRow();
+  const data = last >= 2 ? sheet.getRange(2, 1, last - 1, 2).getValues() : [];
+  for (let i = 0; i < data.length; i++) {
+    if (data[i][0] === key) {
+      sheet.getRange(i + 2, 2).setValue(value);
+      return;
+    }
+  }
+  sheet.appendRow([key, value]);
+}

--- a/tools/gas-sheet-sync/push.gs
+++ b/tools/gas-sheet-sync/push.gs
@@ -1,0 +1,127 @@
+/**
+ * push.gs — Spreadsheet を JSON に再構築して GitHub に PR 作成
+ *
+ * 権限チェック: PUSH_ALLOWED_EMAIL に一致するユーザのみ実行可。
+ * Pull した時点の SHA (lastSyncedSha) と現在の main HEAD を比較し、
+ * ズレていれば warn (force push したいなら Yes で続行)。
+ */
+
+/** メニュー: 全シート push (PR 作成) */
+function pushAllToGitHubAsPR() {
+  const ui = SpreadsheetApp.getUi();
+  try {
+    ghAssertPushAllowed_();
+  } catch (e) {
+    ui.alert(e.message);
+    return;
+  }
+
+  // 1. シートから JSON 構築
+  const built = [];
+  for (const schema of ALL_SCHEMAS) {
+    const json = readSheetAsJson_(schema);
+    built.push({ schema: schema, jsonStr: prettyJsonString_(json, schema) });
+  }
+
+  // 2. main HEAD と lastSyncedSha を比較
+  const props = ghProps_();
+  const headSha = ghGetRefSha(props.base);
+  const lastSyncedSha = getMetaValue_("lastSyncedSha");
+  let staleWarning = "";
+  if (lastSyncedSha && lastSyncedSha !== headSha) {
+    staleWarning = "\n⚠️ 警告: pull した時点の SHA (" + String(lastSyncedSha).substring(0,7) + ") と現在の main HEAD (" + headSha.substring(0,7) + ") が異なります。pull し直してから push することを推奨します。";
+  }
+
+  // 3. diff 確認 — 各ファイルの現在内容を取得して比較、変更が無ければ skip
+  const changedFiles = [];
+  for (const item of built) {
+    const current = ghGetFile(item.schema.jsonPath, props.base);
+    const currentStr = Utilities.newBlob(Utilities.base64Decode(current.content.replace(/\n/g, ""))).getDataAsString();
+    if (currentStr.trim() === item.jsonStr.trim()) continue;
+    changedFiles.push({ path: item.schema.jsonPath, jsonStr: item.jsonStr, sha: current.sha });
+  }
+  if (changedFiles.length === 0) {
+    ui.alert("変更なし\nGitHub の最新と一致しているため PR は作成されません。" + staleWarning);
+    return;
+  }
+
+  // 4. 確認
+  const fileList = changedFiles.map(f => "  - " + f.path).join("\n");
+  const confirm = ui.alert(
+    "Push 確認",
+    "以下の " + changedFiles.length + " ファイルを変更して PR を作成します:\n\n" + fileList + "\n\nbase: " + props.base + staleWarning + "\n\n続行しますか?",
+    ui.ButtonSet.YES_NO,
+  );
+  if (confirm !== ui.Button.YES) return;
+
+  // 5. 新ブランチ作成
+  const ts = Utilities.formatDate(new Date(), "Asia/Tokyo", "yyyyMMdd-HHmmss");
+  const branch = "balance/sheet-sync-" + ts;
+  ghCreateBranch(branch, headSha);
+
+  // 6. 各ファイル PUT
+  for (const f of changedFiles) {
+    ghPutFile(f.path, branch, f.jsonStr, "balance: " + f.path + " (sheet sync)", f.sha);
+  }
+
+  // 7. PR 作成
+  const title = "balance: シート同期 (" + ts + ")";
+  const body =
+    "Spreadsheet からの自動 PR\n\n" +
+    "## 変更ファイル\n" +
+    changedFiles.map(f => "- `" + f.path + "`").join("\n") + "\n\n" +
+    "## 実行情報\n" +
+    "- 実行ユーザ: " + (Session.getActiveUser().getEmail() || "(unknown)") + "\n" +
+    "- 実行時刻: " + new Date().toISOString() + "\n" +
+    "- base SHA: " + headSha + "\n" +
+    "- 元 pull SHA: " + (lastSyncedSha || "(未記録)") + "\n";
+  const pr = ghCreatePullRequest(title, branch, props.base, body);
+
+  // 8. 通知
+  setMetaValue_("lastPushAt", new Date().toISOString());
+  setMetaValue_("lastPushBy", Session.getActiveUser().getEmail() || "(unknown)");
+  setMetaValue_("lastPushBranch", branch);
+  setMetaValue_("lastPushPr", pr.html_url);
+  ui.alert("PR 作成完了\n" + pr.html_url + "\n\n" + changedFiles.length + " ファイル変更。");
+}
+
+/** シートを読み JSON 配列に再構築 */
+function readSheetAsJson_(schema) {
+  const ss = SpreadsheetApp.getActive();
+  const sheet = ss.getSheetByName(schema.sheetName);
+  if (!sheet) throw new Error("シートが存在しません: " + schema.sheetName + "\n先に [Pull] を実行してシートを作成してください。");
+
+  const last = sheet.getLastRow();
+  if (last < 2) return [];
+  const cols = schema.columns;
+  const data = sheet.getRange(2, 1, last - 1, cols.length).getValues();
+  const out = [];
+  data.forEach((row, rowIdx) => {
+    // 全列が空の行は skip (シート末尾の余白)
+    if (row.every(cell => cell === "" || cell === null)) return;
+    const obj = {};
+    cols.forEach((col, colIdx) => {
+      try {
+        const v = coerceValue_(row[colIdx], col.type);
+        if (v !== null) obj[col.name] = v;
+      } catch (e) {
+        throw new Error("行 " + (rowIdx + 2) + " 列 " + col.name + ": " + e.message);
+      }
+    });
+    out.push(obj);
+  });
+  return out;
+}
+
+/** 元 JSON と同じ整形 (2 space indent + 末尾改行) で文字列化 */
+function prettyJsonString_(jsonArray, schema) {
+  // heroes.json と ll-extensions.json は配列形式で、フィールド順序は schema.columns 順序に揃える
+  const ordered = jsonArray.map(item => {
+    const o = {};
+    for (const col of schema.columns) {
+      if (item[col.name] !== undefined) o[col.name] = item[col.name];
+    }
+    return o;
+  });
+  return JSON.stringify(ordered, null, 2) + "\n";
+}

--- a/tools/gas-sheet-sync/schema.gs
+++ b/tools/gas-sheet-sync/schema.gs
@@ -1,0 +1,68 @@
+/**
+ * schema.gs — heroes / ll-extensions の列定義 + dropdown 候補
+ *
+ * 列順序がそのまま JSON フィールド順序になる。新しいフィールドは末尾追加で
+ * 既存シートを破壊せずに拡張可能 (列削除は注意 — push 時に値消失)。
+ */
+
+const SHEET_HEROES   = "heroes";
+const SHEET_LL_EXT   = "ll-extensions";
+const SHEET_META     = "_meta";   // sync 状態 (lastSyncedSha, lastPullAt 等) を置く隠しシート
+
+const PATH_HEROES = "prototype/data/heroes.json";
+const PATH_LL_EXT = "prototype/data/ll-extensions.json";
+
+/** heroes.json の列スキーマ */
+const HEROES_SCHEMA = {
+  sheetName: SHEET_HEROES,
+  jsonPath: PATH_HEROES,
+  // 列定義 — name は JSON フィールド名、type は "int" / "string" / "enum"
+  columns: [
+    { name: "heroId",      type: "int" },
+    { name: "nameJa",      type: "string" },
+    { name: "rarity",      type: "enum", options: ["common", "uncommon", "rare", "epic", "legendary"] },
+    { name: "hpMax",       type: "int" },
+    { name: "basePhy",     type: "int" },
+    { name: "baseInt",     type: "int" },
+    { name: "baseAgi",     type: "int" },
+    { name: "passiveKey",  type: "string" },
+    { name: "passiveName", type: "string" },
+    { name: "passiveDesc", type: "string" },
+  ],
+};
+
+/** ll-extensions.json の列スキーマ */
+const LL_EXT_SCHEMA = {
+  sheetName: SHEET_LL_EXT,
+  jsonPath: PATH_LL_EXT,
+  columns: [
+    { name: "extId",     type: "int" },
+    { name: "name",      type: "string" },
+    { name: "skillName", type: "string" },
+    { name: "rarity",    type: "enum", options: ["ll"] },
+    { name: "effectKey", type: "string" },  // 注: ハードコード参照のため自由入力時は実装側を必ず確認
+    { name: "desc",      type: "string" },
+  ],
+};
+
+const ALL_SCHEMAS = [HEROES_SCHEMA, LL_EXT_SCHEMA];
+
+/** value を type に応じて型変換 (sheet → JSON 用) */
+function coerceValue_(value, type) {
+  if (value === "" || value === null || value === undefined) return null;
+  if (type === "int") {
+    const n = Number(value);
+    if (!Number.isFinite(n)) throw new Error("整数として読めません: " + value);
+    return Math.trunc(n);
+  }
+  if (type === "string" || type === "enum") {
+    return String(value);
+  }
+  return value;
+}
+
+/** value を sheet 表示用に変換 (JSON → sheet 用) */
+function displayValue_(value) {
+  if (value === null || value === undefined) return "";
+  return value;
+}


### PR DESCRIPTION
## Summary

テスターが Spreadsheet でパラメータを編集 → ボタン 1 つで GitHub PR を作成できる Container-bound GAS スクリプト一式。P1 として `heroes.json` (210 件) と `ll-extensions.json` (6 件) のフラット 2 ファイルを対象。

## 機能

- **Pull (誰でも実行可)**: GitHub main の最新 JSON を Spreadsheet に流し込む
- **Push (`bearko.miyamoto@gmail.com` のみ実行可)**: Spreadsheet を JSON に再構築 → 新ブランチ + PR 作成
- `rarity` 列はプルダウン
- `_meta` 隠しシートで pull/push の SHA・実行ユーザを記録 → スプレッドシートが古いまま push しないよう警告

## 権限分離

`Session.getActiveUser().getEmail()` で実行ユーザを判定し、`PUSH_ALLOWED_EMAIL` ScriptProperty (= `bearko.miyamoto@gmail.com`) と一致しない場合 Push を弾く。テスターは閲覧・編集のみ可、Push 時は bearko 本人がボタンを押す運用。

## ファイル構成 (`tools/gas-sheet-sync/`)

| ファイル | 役割 |
|---|---|
| `README.md` | セットアップ手順 (PAT 発行手順、Properties 設定、運用フロー、トラブルシューティング) |
| `appsscript.json` | OAuth scope (spreadsheets / external_request / userinfo.email) |
| `menu.gs` | onOpen でカスタムメニュー追加 + 設定確認 |
| `pull.gs` | raw.githubusercontent.com から JSON fetch → シート書込み + dropdown 設定 |
| `push.gs` | シート → JSON 再構築 → 新ブランチ + ファイル PUT + PR 作成 |
| `github.gs` | GitHub API ヘルパ (Auth, refs, contents, pulls) |
| `schema.gs` | heroes / ll-extensions の列定義 + dropdown 候補 |

## セットアップ手順 (README から抜粋)

1. 新規 Spreadsheet 作成 → 拡張機能 → Apps Script
2. このディレクトリの `.gs` / `appsscript.json` を貼り付け
3. ScriptProperties 5 件を設定:
   - `GITHUB_PAT` (下記 4. で発行)
   - `GITHUB_OWNER` = `bearko`
   - `GITHUB_REPO` = `mycryptotactics`
   - `GITHUB_BASE_BRANCH` = `main`
   - `PUSH_ALLOWED_EMAIL` = `bearko.miyamoto@gmail.com`
4. fine-grained PAT 発行 (Contents R/W + PR R/W、`bearko/mycryptotactics` のみ)
5. Spreadsheet をリロードで「データ同期」メニュー表示
6. [Pull] 実行 → `heroes` / `ll-extensions` / `_meta` シートが自動生成

詳細は [tools/gas-sheet-sync/README.md](tools/gas-sheet-sync/README.md) 参照。

## 動作フロー

### Pull
1. `_meta` から `lastSyncedSha` を読む (情報用)
2. raw.githubusercontent.com から `heroes.json` / `ll-extensions.json` を anonymous fetch
3. シートを clear → header + dropdown + データ流し込み
4. `_meta` に lastSyncedSha (= main HEAD SHA), lastPullAt, lastPullBy を記録

### Push
1. 実行ユーザのメールを `PUSH_ALLOWED_EMAIL` と照合
2. シートを読んで JSON 配列を再構築
3. 現在の main HEAD SHA を取得し、`lastSyncedSha` と差分があれば警告
4. 各ファイルの現在内容を取得し diff 確認 (変更なしなら skip)
5. 確認ダイアログ
6. 新ブランチ `balance/sheet-sync-{timestamp}` を main HEAD から作成
7. 変更ファイルを PUT
8. PR 作成 (タイトル: "balance: シート同期 (yyyyMMdd-HHmmss)")
9. PR URL をアラート表示 + `_meta` に記録

## P1 の制約

- 配列形式 JSON のみ対応 (heroes, ll-extensions)
- `enemies.json` / `bosses.json` は intentRota / phases ネストがあるため P2/P3 で別途対応
- `effectKey` (ll-extensions) は文字列キーで自由入力可だが、JS 実装側に対応がないと動かない (P4 で declarative 化予定)
- 同時 Push の競合は手動運用 (タイムスタンプベースのブランチ名で衝突回避)

## Test plan (動作確認手順)

- [ ] README 通りに Spreadsheet + GAS をセットアップ
- [ ] [Script Properties をチェック] で 5 件設定済みの確認 alert が出る
- [ ] [Pull] 実行 → heroes / ll-extensions / _meta シートが作られる
- [ ] heroes シートで rarity 列のドロップダウンが効く (5 値から選択可)
- [ ] heroes の任意の hpMax を変更 → [Push] → 確認ダイアログ → Yes
- [ ] PR が作成され URL がアラートに出る
- [ ] PR 内容を確認 — 変更行のみ diff、JSON 整形 OK
- [ ] テスターアカウント (bearko 以外) で [Push] → "Push 権限がありません" エラーが出る
- [ ] 別 commit 後に [Push] → "lastSyncedSha と main HEAD が異なります" 警告が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)