### PR TITLE
chore(rights): 権利関係 NG ヒーロー 8 体 + エクステンション 13 件削除

### DIFF
--- a/prototype/data/heroes.json
+++ b/prototype/data/heroes.json
@@ -708,18 +708,6 @@
     "passiveDesc": "戦闘開始時に発動・敵のAGI-1／敵に出血×1付与"
   },
   {
-    "heroId": 2050,
-    "nameJa": "イッパツマン & 逆転王",
-    "rarity": "uncommon",
-    "hpMax": 85,
-    "basePhy": 16,
-    "baseInt": 6,
-    "baseAgi": 13,
-    "passiveKey": "ippatsuman",
-    "passiveName": "逆転王、見参!!",
-    "passiveDesc": "戦闘開始時に発動・自身のPHY+5／ガード+6"
-  },
-  {
     "heroId": 2051,
     "nameJa": "アーマロイド・レディ",
     "rarity": "uncommon",
@@ -1356,30 +1344,6 @@
     "passiveDesc": "戦闘開始時に発動・自身のPHY+6"
   },
   {
-    "heroId": 3052,
-    "nameJa": "キャシャーン & フレンダー",
-    "rarity": "rare",
-    "hpMax": 90,
-    "basePhy": 12,
-    "baseInt": 18,
-    "baseAgi": 10,
-    "passiveKey": "casshern",
-    "passiveName": "超破壊光線",
-    "passiveDesc": "戦闘開始時に発動・敵にINT60〜70%ダメージ"
-  },
-  {
-    "heroId": 3053,
-    "nameJa": "クリスタル・ボーイ",
-    "rarity": "rare",
-    "hpMax": 90,
-    "basePhy": 9,
-    "baseInt": 9,
-    "baseAgi": 22,
-    "passiveKey": "crystal_boy",
-    "passiveName": "ライブ・クリスタル",
-    "passiveDesc": "カード使用後に発動・自身のAGI+1／シールド+8"
-  },
-  {
     "heroId": 3054,
     "nameJa": "DOURAN",
     "rarity": "rare",
@@ -1884,30 +1848,6 @@
     "passiveDesc": "カード使用後に発動・自身のPHY+3／敵に毒×3付与"
   },
   {
-    "heroId": 4042,
-    "nameJa": "ブッダ",
-    "rarity": "epic",
-    "hpMax": 120,
-    "basePhy": 7,
-    "baseInt": 20,
-    "baseAgi": 7,
-    "passiveKey": "buddha",
-    "passiveName": "悟り",
-    "passiveDesc": "戦闘開始時に発動・自身のINT+1／自身のAGI+2"
-  },
-  {
-    "heroId": 4043,
-    "nameJa": "鉄腕アトム",
-    "rarity": "epic",
-    "hpMax": 95,
-    "basePhy": 18,
-    "baseInt": 11,
-    "baseAgi": 19,
-    "passiveKey": "atom",
-    "passiveName": "10万馬力",
-    "passiveDesc": "カード使用後に発動・自身のPHY+1"
-  },
-  {
     "heroId": 4044,
     "nameJa": "ファーブル",
     "rarity": "epic",
@@ -2076,30 +2016,6 @@
     "passiveDesc": "戦闘開始時・自身のPHY+1（DBに無い効果のため代替）"
   },
   {
-    "heroId": 4058,
-    "nameJa": "ヤッターマン1号 & 2号",
-    "rarity": "epic",
-    "hpMax": 95,
-    "basePhy": 11,
-    "baseInt": 11,
-    "baseAgi": 25,
-    "passiveKey": "yatterman",
-    "passiveName": "ケンダマジック & シビレステッキ",
-    "passiveDesc": "カード使用後に発動・敵にINT25〜25%ダメージ／敵に出血×3付与"
-  },
-  {
-    "heroId": 4059,
-    "nameJa": "コブラ",
-    "rarity": "epic",
-    "hpMax": 95,
-    "basePhy": 7,
-    "baseInt": 22,
-    "baseAgi": 21,
-    "passiveKey": "cobra",
-    "passiveName": "サイコガン",
-    "passiveDesc": "カード使用後に発動・自身のINT+6"
-  },
-  {
     "heroId": 4060,
     "nameJa": "SUZUISHI",
     "rarity": "epic",
@@ -2110,18 +2026,6 @@
     "passiveKey": "suzuishi",
     "passiveName": "鳴響止水",
     "passiveDesc": "カード使用後に発動・敵にPHY30〜30%ダメージ／自身のPHY+7"
-  },
-  {
-    "heroId": 4061,
-    "nameJa": "ティルフィング[PK Alterna]",
-    "rarity": "epic",
-    "hpMax": 95,
-    "basePhy": 24,
-    "baseInt": 7,
-    "baseAgi": 18,
-    "passiveKey": "tyrfing",
-    "passiveName": "ショックトゥキル",
-    "passiveDesc": "カード使用後に発動・敵にPHY20〜25%ダメージ／シールド+8"
   },
   {
     "heroId": 5001,

--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -1750,29 +1750,7 @@ function makeCardLibrary(clog, api) {
         s.playerInt += 1;
       },
     },
-    ext1060: {
-      libraryKey: "ext1060",
-      extId: 1060,
-      extNameJa: "ヒョウタンツギ",
-      skillNameJa: "新種のキノコ",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 45-45%" },
-        { target: "enemy.foremost", text: "出血 ×1" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 45, 45)}`, "出血 ×1（敵）"]; },
-      peekHelpKeys() { return []; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 45, 45)} ダメージ（PHY 45〜45%）`, "敵に出血 ×1 付与"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 45, 45);
-        api.addBleedToEnemy(s, 1);
-      },
-    },
+
     ext1061: {
       libraryKey: "ext1061",
       extId: 1061,
@@ -5551,29 +5529,7 @@ function makeCardLibrary(clog, api) {
         s.playerInt += 1;
       },
     },
-    ext2060: {
-      libraryKey: "ext2060",
-      extId: 2060,
-      extNameJa: "ロビタ",
-      skillNameJa: "レオナの記憶",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 45-45%" },
-        { target: "enemy.foremost", text: "出血 ×1" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 45, 45)}`, "出血 ×1（敵）"]; },
-      peekHelpKeys() { return []; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 45, 45)} ダメージ（PHY 45〜45%）`, "敵に出血 ×1 付与"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 45, 45);
-        api.addBleedToEnemy(s, 1);
-      },
-    },
+
     ext2061: {
       libraryKey: "ext2061",
       extId: 2061,
@@ -5595,29 +5551,7 @@ function makeCardLibrary(clog, api) {
         api.healPlayerFromIntSkill(s, 40, 50);
       },
     },
-    ext2062: {
-      libraryKey: "ext2062",
-      extId: 2062,
-      extNameJa: "創輝剣ベルテ",
-      skillNameJa: "グロウ・レゾナンス",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 45-55%" },
-        { target: "enemy.foremost", text: "出血 ×1" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 45, 55)}`, "出血 ×1（敵）"]; },
-      peekHelpKeys() { return []; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 45, 55)} ダメージ（PHY 45〜55%）`, "敵に出血 ×1 付与"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 45, 55);
-        api.addBleedToEnemy(s, 1);
-      },
-    },
+
     ext2063: {
       libraryKey: "ext2063",
       extId: 2063,
@@ -6435,29 +6369,7 @@ function makeCardLibrary(clog, api) {
         api.addPoisonToEnemy(s, 1);
       },
     },
-    ext2101: {
-      libraryKey: "ext2101",
-      extId: 2101,
-      extNameJa: "リリエッタの盾",
-      skillNameJa: "鉄壁の防御",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 50-50%" },
-        { target: "self", text: "PHY +2" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 50, 50)}`, "PHY\u3000+2"]; },
-      peekHelpKeys() { return ["phy"]; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 50, 50)} ダメージ（PHY 50〜50%）`, "PHY を +2"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 50, 50);
-        s.playerPhy += 2;
-      },
-    },
+
     ext2102: {
       libraryKey: "ext2102",
       extId: 2102,
@@ -9719,29 +9631,7 @@ function makeCardLibrary(clog, api) {
         s.playerInt += 2;
       },
     },
-    ext3060: {
-      libraryKey: "ext3060",
-      extId: 3060,
-      extNameJa: "ユニコ",
-      skillNameJa: "愛を取らないでください",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 50-50%" },
-        { target: "enemy.foremost", text: "出血 ×2" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 50, 50)}`, "出血 ×2（敵）"]; },
-      peekHelpKeys() { return []; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 50, 50)} ダメージ（PHY 50〜50%）`, "敵に出血 ×2 付与"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 50, 50);
-        api.addBleedToEnemy(s, 2);
-      },
-    },
+
     ext3061: {
       libraryKey: "ext3061",
       extId: 3061,
@@ -9763,29 +9653,7 @@ function makeCardLibrary(clog, api) {
         api.healPlayerFromIntSkill(s, 50, 60);
       },
     },
-    ext3062: {
-      libraryKey: "ext3062",
-      extId: 3062,
-      extNameJa: "創聖剣ベラネル",
-      skillNameJa: "ホーリー・レゾナンス",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 50-60%" },
-        { target: "enemy.foremost", text: "出血 ×2" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 50, 60)}`, "出血 ×2（敵）"]; },
-      peekHelpKeys() { return []; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 50, 60)} ダメージ（PHY 50〜60%）`, "敵に出血 ×2 付与"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 50, 60);
-        api.addBleedToEnemy(s, 2);
-      },
-    },
+
     ext3063: {
       libraryKey: "ext3063",
       extId: 3063,
@@ -10540,27 +10408,7 @@ function makeCardLibrary(clog, api) {
         api.addPoisonToEnemy(s, 2);
       },
     },
-    ext3101: {
-      libraryKey: "ext3101",
-      extId: 3101,
-      extNameJa: "モクク",
-      skillNameJa: "癒しボイス",
-      skillIcon: "hp.png",
-      cost: 1,
-      type: "skl",
-      target: "self",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "self", text: "HP回復 INT40-40%" }
-      ],
-      effectSummaryLines(s) { return ["HP\u3000+" + estHealInt(s.playerInt, s.playerPhy, 40, 40)]; },
-      peekHelpKeys() { return ["hp"]; },
-      previewLines(s) { return [`HP を回復係数 40〜40% 分回復（推定 +${estHealInt(s.playerInt, s.playerPhy, 40, 40)}）`]; },
-      play(s) {
-        api.healPlayerFromIntSkill(s, 40, 40);
-      },
-    },
+
     ext3102: {
       libraryKey: "ext3102",
       extId: 3102,
@@ -13859,29 +13707,7 @@ function makeCardLibrary(clog, api) {
         s.playerInt += 2;
       },
     },
-    ext4060: {
-      libraryKey: "ext4060",
-      extId: 4060,
-      extNameJa: "レオ",
-      skillNameJa: "ジャングル大帝",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 55-55%" },
-        { target: "enemy.foremost", text: "出血 ×3" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 55, 55)}`, "出血 ×3（敵）"]; },
-      peekHelpKeys() { return []; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 55, 55)} ダメージ（PHY 55〜55%）`, "敵に出血 ×3 付与"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 55, 55);
-        api.addBleedToEnemy(s, 3);
-      },
-    },
+
     ext4061: {
       libraryKey: "ext4061",
       extId: 4061,
@@ -14663,33 +14489,7 @@ function makeCardLibrary(clog, api) {
         api.addPoisonToEnemy(s, 3);
       },
     },
-    ext4101: {
-      libraryKey: "ext4101",
-      extId: 4101,
-      extNameJa: "マモリ",
-      skillNameJa: "エロ防具じゃないマモ！",
-      skillIcon: "int.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "INTダメ 5-5%" },
-        { target: "self", text: "PHY +1" },
-        { target: "self", text: "INT +1" },
-        { target: "enemy.foremost", text: "毒 ×3" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estIntHit(s.playerInt, s.enemyInt, 5, 5)}`, "PHY\u3000+1", "INT\u3000+1", "毒 ×3（敵）"]; },
-      peekHelpKeys() { return ["phy", "int"]; },
-      previewLines(s) { return [`敵1体に ${estIntHit(s.playerInt, s.enemyInt, 5, 5)} ダメージ（INT 5〜5%）`, "PHY を +1", "INT を +1", "敵に毒 ×3 付与"]; },
-      play(s) {
-        api.dealIntSkillToEnemy(s, 5, 5);
-        s.playerPhy += 1;
-        s.playerInt += 1;
-        api.addPoisonToEnemy(s, 3);
-      },
-    },
+
     ext4102: {
       libraryKey: "ext4102",
       extId: 4102,
@@ -16095,75 +15895,9 @@ function makeCardLibrary(clog, api) {
         api.dealIntSkillToEnemy(s, 65, 75);
       },
     },
-    ext4166: {
-      libraryKey: "ext4166",
-      extId: 4166,
-      extNameJa: "レーヴァテイン[PK Alterna]",
-      skillNameJa: "大切な仲間だし！",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 40-45%" },
-        { target: "self", text: "PHY +3" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 40, 45)}`, "PHY\u3000+3"]; },
-      peekHelpKeys() { return ["phy"]; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 40, 45)} ダメージ（PHY 40〜45%）`, "PHY を +3"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 40, 45);
-        s.playerPhy += 3;
-      },
-    },
-    ext4167: {
-      libraryKey: "ext4167",
-      extId: 4167,
-      extNameJa: "アルマス[PK Alterna]",
-      skillNameJa: "絶対解放戦線",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 25-35%" },
-        { target: "enemy.foremost", text: "INTダメ 25-35%" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 25, 35)}`, `敵にダメージ\u3000${estIntHit(s.playerInt, s.enemyInt, 25, 35)}`]; },
-      peekHelpKeys() { return []; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 25, 35)} ダメージ（PHY 25〜35%）`, `敵全体相当に ${estIntHit(s.playerInt, s.enemyInt, 25, 35)} ダメージ（INT 25〜35%・1v1=単体）`]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 25, 35);
-        api.playBattleSe("area"); api.dealIntSkillToEnemy(s, 25, 35);
-      },
-    },
-    ext4168: {
-      libraryKey: "ext4168",
-      extId: 4168,
-      extNameJa: "フェイルノート[PK Alterna]",
-      skillNameJa: "誓約されし明星の魔弓",
-      skillIcon: "int.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "INTダメ 25-40%" },
-        { target: "self", text: "INT +2" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estIntHit(s.playerInt, s.enemyInt, 25, 40)}`, "INT\u3000+2"]; },
-      peekHelpKeys() { return ["int"]; },
-      previewLines(s) { return [`敵全体相当に ${estIntHit(s.playerInt, s.enemyInt, 25, 40)} ダメージ（INT 25〜40%・1v1=単体）`, "INT を +2"]; },
-      play(s) {
-        api.playBattleSe("area"); api.dealIntSkillToEnemy(s, 25, 40);
-        s.playerInt += 2;
-      },
-    },
+
+
+
     ext4169: {
       libraryKey: "ext4169",
       extId: 4169,
@@ -18107,29 +17841,7 @@ function makeCardLibrary(clog, api) {
         s.playerInt += 3;
       },
     },
-    ext5060: {
-      libraryKey: "ext5060",
-      extId: 5060,
-      extNameJa: "火の鳥",
-      skillNameJa: "永遠の生命",
-      skillIcon: "phy.png",
-      cost: 1,
-      type: "atk",
-      target: "enemy.foremost",
-      caster: "foremost",
-      // SPEC-006: auto-derived effects (review needed: no)
-      effects: [
-        { target: "enemy.foremost", text: "PHYダメ 65-65%" },
-        { target: "enemy.foremost", text: "出血 ×4" }
-      ],
-      effectSummaryLines(s) { return [`敵にダメージ\u3000${estPhyHit(s.playerPhy, s.enemyPhy, 65, 65)}`, "出血 ×4（敵）"]; },
-      peekHelpKeys() { return []; },
-      previewLines(s) { return [`敵1体に ${estPhyHit(s.playerPhy, s.enemyPhy, 65, 65)} ダメージ（PHY 65〜65%）`, "敵に出血 ×4 付与"]; },
-      play(s) {
-        api.dealPhySkillToEnemy(s, 65, 65);
-        api.addBleedToEnemy(s, 4);
-      },
-    },
+
     ext5061: {
       libraryKey: "ext5061",
       extId: 5061,
@@ -20970,9 +20682,7 @@ export const CARD_RARITIES = {
   ext1056: 'common',
   ext1057: 'common',
   ext1058: 'common',
-  ext1059: 'common',
-  ext1060: 'common',
-  ext1061: 'common',
+  ext1059: 'common',  ext1061: 'common',
   ext1063: 'common',
   ext1064: 'common',
   ext1065: 'common',
@@ -21141,11 +20851,7 @@ export const CARD_RARITIES = {
   ext2056: 'uncommon',
   ext2057: 'uncommon',
   ext2058: 'uncommon',
-  ext2059: 'uncommon',
-  ext2060: 'uncommon',
-  ext2061: 'uncommon',
-  ext2062: 'uncommon',
-  ext2063: 'uncommon',
+  ext2059: 'uncommon',  ext2061: 'uncommon',  ext2063: 'uncommon',
   ext2064: 'uncommon',
   ext2065: 'uncommon',
   ext2066: 'uncommon',
@@ -21181,9 +20887,7 @@ export const CARD_RARITIES = {
   ext2097: 'uncommon',
   ext2098: 'uncommon',
   ext2099: 'uncommon',
-  ext2100: 'uncommon',
-  ext2101: 'uncommon',
-  ext2102: 'uncommon',
+  ext2100: 'uncommon',  ext2102: 'uncommon',
   ext2103: 'uncommon',
   ext2104: 'uncommon',
   ext2105: 'uncommon',
@@ -21330,11 +21034,7 @@ export const CARD_RARITIES = {
   ext3056: 'rare',
   ext3057: 'rare',
   ext3058: 'rare',
-  ext3059: 'rare',
-  ext3060: 'rare',
-  ext3061: 'rare',
-  ext3062: 'rare',
-  ext3063: 'rare',
+  ext3059: 'rare',  ext3061: 'rare',  ext3063: 'rare',
   ext3064: 'rare',
   ext3065: 'rare',
   ext3066: 'rare',
@@ -21367,9 +21067,7 @@ export const CARD_RARITIES = {
   ext3097: 'rare',
   ext3098: 'rare',
   ext3099: 'rare',
-  ext3100: 'rare',
-  ext3101: 'rare',
-  ext3102: 'rare',
+  ext3100: 'rare',  ext3102: 'rare',
   ext3103: 'rare',
   ext3104: 'rare',
   ext3105: 'rare',
@@ -21516,9 +21214,7 @@ export const CARD_RARITIES = {
   ext4056: 'epic',
   ext4057: 'epic',
   ext4058: 'epic',
-  ext4059: 'epic',
-  ext4060: 'epic',
-  ext4061: 'epic',
+  ext4059: 'epic',  ext4061: 'epic',
   ext4063: 'epic',
   ext4064: 'epic',
   ext4065: 'epic',
@@ -21552,9 +21248,7 @@ export const CARD_RARITIES = {
   ext4097: 'epic',
   ext4098: 'epic',
   ext4099: 'epic',
-  ext4100: 'epic',
-  ext4101: 'epic',
-  ext4102: 'epic',
+  ext4100: 'epic',  ext4102: 'epic',
   ext4103: 'epic',
   ext4104: 'epic',
   ext4105: 'epic',
@@ -21616,11 +21310,7 @@ export const CARD_RARITIES = {
   ext4162: 'epic',
   ext4163: 'epic',
   ext4164: 'epic',
-  ext4165: 'epic',
-  ext4166: 'epic',
-  ext4167: 'epic',
-  ext4168: 'epic',
-  ext4169: 'epic',
+  ext4165: 'epic',  ext4169: 'epic',
   ext4170: 'epic',
   ext4171: 'epic',
   ext4172: 'epic',
@@ -21706,9 +21396,7 @@ export const CARD_RARITIES = {
   ext5056: 'legendary',
   ext5057: 'legendary',
   ext5058: 'legendary',
-  ext5059: 'legendary',
-  ext5060: 'legendary',
-  ext5061: 'legendary',
+  ext5059: 'legendary',  ext5061: 'legendary',
   ext5063: 'legendary',
   ext5064: 'legendary',
   ext5065: 'legendary',

--- a/prototype/js/passives-generated.js
+++ b/prototype/js/passives-generated.js
@@ -1,7 +1,7 @@
 /**
  * passives-generated.js — SPEC-006 §18 Phase 4j codemod 出力 (v2)
  *
- * 全 210 体のヒーローパッシブを宣言形式 PassiveDef に変換。
+ * 全 202 体のヒーローパッシブを宣言形式 PassiveDef に変換。
  * 元データ: prototype/data/heroes.json
  * 生成スクリプト: prototype/tools/gen-passives.js
  *
@@ -707,18 +707,6 @@ export const PASSIVES = {
     ],
     cutinSkillName: "ワルツ9番 告別"
   },
-  // heroId: 2050
-  "ippatsuman": {
-    passiveKey: "ippatsuman",
-    trigger: "combat.started",
-    triggerRate: 1,
-    oncePerCombat: true,
-    effects: [
-      {"target":"self","action":"buffStat","stat":"phy","value":5},
-      {"target":"self","action":"addGuard","value":6}
-    ],
-    cutinSkillName: "逆転王、見参!!"
-  },
   // heroId: 2051
   "armaroid": {
     passiveKey: "armaroid",
@@ -1347,29 +1335,6 @@ export const PASSIVES = {
     ],
     cutinSkillName: "天下の草創"
   },
-  // heroId: 3052
-  "casshern": {
-    passiveKey: "casshern",
-    trigger: "combat.started",
-    triggerRate: 1,
-    oncePerCombat: true,
-    effects: [
-      {"target":"enemy.foremost","action":"damage","coef":{"int":0.65}}
-    ],
-    cutinSkillName: "超破壊光線"
-  },
-  // heroId: 3053
-  "crystal_boy": {
-    passiveKey: "crystal_boy",
-    trigger: "self.cardPlayed",
-    triggerRate: 0.4,
-    oncePerCombat: false,
-    effects: [
-      {"target":"self","action":"buffStat","stat":"agi","value":1},
-      {"target":"self","action":"addShield","value":8}
-    ],
-    cutinSkillName: "ライブ・クリスタル"
-  },
   // heroId: 3054
   "douran": {
     passiveKey: "douran",
@@ -1868,29 +1833,6 @@ export const PASSIVES = {
     ],
     cutinSkillName: "テスラコイル"
   },
-  // heroId: 4042
-  "buddha": {
-    passiveKey: "buddha",
-    trigger: "combat.started",
-    triggerRate: 1,
-    oncePerCombat: true,
-    effects: [
-      {"target":"self","action":"buffStat","stat":"int","value":1},
-      {"target":"self","action":"buffStat","stat":"agi","value":2}
-    ],
-    cutinSkillName: "悟り"
-  },
-  // heroId: 4043
-  "atom": {
-    passiveKey: "atom",
-    trigger: "self.cardPlayed",
-    triggerRate: 0.4,
-    oncePerCombat: false,
-    effects: [
-      {"target":"self","action":"buffStat","stat":"phy","value":1}
-    ],
-    cutinSkillName: "10万馬力"
-  },
   // heroId: 4044
   "fabre": {
     passiveKey: "fabre",
@@ -2057,29 +1999,6 @@ export const PASSIVES = {
     ],
     cutinSkillName: "イケニ族の女王"
   },
-  // heroId: 4058
-  "yatterman": {
-    passiveKey: "yatterman",
-    trigger: "self.cardPlayed",
-    triggerRate: 0.4,
-    oncePerCombat: false,
-    effects: [
-      {"target":"enemy.foremost","action":"damage","coef":{"int":0.25}},
-      {"target":"enemy.foremost","action":"applyStatus","status":"bleed","stacks":3}
-    ],
-    cutinSkillName: "ケンダマジック & シビレステッキ"
-  },
-  // heroId: 4059
-  "cobra": {
-    passiveKey: "cobra",
-    trigger: "self.cardPlayed",
-    triggerRate: 0.4,
-    oncePerCombat: false,
-    effects: [
-      {"target":"self","action":"buffStat","stat":"int","value":6}
-    ],
-    cutinSkillName: "サイコガン"
-  },
   // heroId: 4060
   "suzuishi": {
     passiveKey: "suzuishi",
@@ -2091,18 +2010,6 @@ export const PASSIVES = {
       {"target":"self","action":"buffStat","stat":"phy","value":7}
     ],
     cutinSkillName: "鳴響止水"
-  },
-  // heroId: 4061
-  "tyrfing": {
-    passiveKey: "tyrfing",
-    trigger: "self.cardPlayed",
-    triggerRate: 0.4,
-    oncePerCombat: false,
-    effects: [
-      {"target":"enemy.foremost","action":"damage","coef":{"phy":0.225}},
-      {"target":"self","action":"addShield","value":8}
-    ],
-    cutinSkillName: "ショックトゥキル"
   },
   // heroId: 5001
   "nobunaga": {


### PR DESCRIPTION
## Summary

権利関係上使用 NG と通知を受けた以下の 8 ヒーロー / 13 エクステンションを削除。

## 削除対象

### ヒーロー (heroes.json から削除、210 → 202)

| heroId | 名前 | passiveKey |
|---|---|---|
| 2050 | イッパツマン & 逆転王 | ippatsuman |
| 3052 | キャシャーン & フレンダー | casshern |
| 3053 | クリスタル・ボーイ | crystal_boy |
| 4042 | ブッダ | buddha |
| 4043 | 鉄腕アトム | atom |
| 4058 | ヤッターマン1号 & 2号 | yatterman |
| 4059 | コブラ | cobra |
| 4061 | ティルフィング[PK Alterna] | tyrfing |

`passives-generated.js` を新 heroes.json で再生成 (210 → 202 PassiveDefs)。

### エクステンション (cards.js から削除)

| extId | シリーズ | 名前 |
|---|---|---|
| 1060 | 手塚オールスター | ヒョウタンツギ |
| 2060 | 手塚オールスター | ロビタ |
| 3060 | 手塚オールスター | ユニコ |
| 4060 | 手塚オールスター | レオ |
| 5060 | 手塚オールスター | 火の鳥 |
| 2062 | ブレイブ フロンティア ヒーローズ 創剣 | 創輝剣ベルテ |
| 3062 | ブレイブ フロンティア ヒーローズ 創剣 | 創聖剣ベラネル |
| 2101 | おとなの防具屋さん | リリエッタの盾 |
| 3101 | おとなの防具屋さん | モクク |
| 4101 | おとなの防具屋さん | マモリ |
| 4166 | ファンキルオルタナ | レーヴァテイン[PK Alterna] |
| 4167 | ファンキルオルタナ | アルマス[PK Alterna] |
| 4168 | ファンキルオルタナ | フェイルノート[PK Alterna] |

cards.js から:
- 定義ブロック 13 件
- `CARD_RARITIES` エントリ 13 件

を削除。chapters.js の cardPool には参照無し (ボス報酬・章プールへの影響なし)。

### 元々 cards.js に存在しなかった項目 (削除対象外、参考)

通知リストの以下 8 件は cards.js に元々定義されていなかったため触らず:
- 11060/12060/13060/14060/15060 手塚オールスター Rep (F/E/D/C/B)
- 15101/16101/17101 おとなの防具屋さん Rep (B/A/S)

## 残存する参照 (dead code、後続 cleanup 対象)

- `main.js` の `applyHeroPassiveOnCombatStart` / `OnCardUse` switch case に passiveKey 8 件残存
  - 該当 LEADER がいないため呼ばれることはない (heroes.json から削除済み)
  - 既存の `getRegisteredPassive` 早期 return ロジックでも skip される
- `tools/gen-*-heroes.js` の PASSIVE_KEYS マッピングに heroId 残存
  - 新 codemod `gen-passives.js` は heroes.json 直読みなので影響なし
  - 旧 codemod は使われなくなったので別 PR で削除予定

## Test plan

- [ ] ヒーロー選択画面で 8 体が出ないこと
- [ ] バトル中のリワード / ショップ / クラフトで 13 エクステが出ないこと
- [ ] 既存セーブ (もしあれば) で削除済みヒーロー/エクステが選択されてないことを確認
- [ ] チャプタープレイで報酬カードプール正常 (ext1060 系の章別報酬が無いことを確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)