### PR TITLE
feat(sheet-sync): extensions シート (Pull-only、cards.js parse) 追加

### DIFF
--- a/tools/gas-sheet-sync/README.md
+++ b/tools/gas-sheet-sync/README.md
@@ -14,12 +14,21 @@
 
 ## 対象 JSON
 
-| sheet 名 | path |
-|---|---|
-| `heroes` | `prototype/data/heroes.json` (210 件) |
-| `ll-extensions` | `prototype/data/ll-extensions.json` (6 件) |
+| sheet 名 | path | Pull | Push | 件数 |
+|---|---|---|---|---|
+| `heroes` | `prototype/data/heroes.json` | ✓ | ✓ | 202 |
+| `ll-extensions` | `prototype/data/ll-extensions.json` | ✓ | ✓ | 6 |
+| `extensions` | `prototype/js/cards.js` (parse) | ✓ | ✗ | 920 |
 
 `enemies.json` / `bosses.json` は P2 / P3 で対応 (intentRota / phases のネストがあるため別シート分離設計が必要)。
+
+### extensions シートについて
+
+- **view 専用** (Pull-only)。cards.js には `play()` 等の JS 関数本体が含まれるため Push (書き戻し) は危険なので未対応。
+- ヘッダの背景色が赤系 (`#fce4ec`) で他シート (青系) と視覚的に区別。
+- セル編集しても Push には反映されません (Pull で上書き)。
+- カード一覧の閲覧 / フィルタリング / ソート用です。
+- 抽出フィールド: `libraryKey` / `extId` / `extNameJa` / `skillNameJa` / `skillIcon` / `cost` / `type` / `target` / `caster` / `rarity` / `effect_1〜3 (target / text)`
 
 ---
 

--- a/tools/gas-sheet-sync/extensions-parser.gs
+++ b/tools/gas-sheet-sync/extensions-parser.gs
@@ -1,0 +1,119 @@
+/**
+ * extensions-parser.gs — cards.js から extension エンティティを抽出
+ *
+ * cards.js は JS のメソッド (effectSummaryLines / play / etc.) を含む大きな
+ * ファイルなので、AST ではなく正規表現で **データフィールドのみ** を抽出する。
+ * Push (cards.js への書き戻し) はサポートせず、Pull (View) 専用。
+ *
+ * 各 ext エントリの抽出フィールド:
+ *   libraryKey, extId, extNameJa, skillNameJa, skillIcon,
+ *   cost, type, target, caster, effects (array)
+ * + CARD_RARITIES から rarity を結合
+ */
+
+/** raw cards.js テキストから ext エントリ配列を抽出 */
+function parseExtensionsFromCardsJs_(text) {
+  const out = [];
+  // まず CARD_RARITIES dict を抽出 (cards.js 末尾)
+  const rarities = parseCardRarities_(text);
+
+  // 各 ext エントリのスタートを find: "    ext1234: {"
+  const startRe = /^( {4})ext(\d+):\s*\{$/gm;
+  let m;
+  while ((m = startRe.exec(text)) !== null) {
+    const indent = m[1];
+    const extId = +m[2];
+    const blockStart = m.index;
+    // 対応する閉じ "    }," を探す (同 indent + },)
+    const closeRe = new RegExp("^" + indent + "\\},?$", "m");
+    closeRe.lastIndex = blockStart + m[0].length;
+    const closeMatch = closeRe.exec(text.substring(blockStart));
+    if (!closeMatch) continue;
+    const blockEnd = blockStart + closeMatch.index + closeMatch[0].length;
+    const block = text.substring(blockStart, blockEnd);
+    const entry = parseExtBlock_(block);
+    if (entry) {
+      entry.rarity = rarities[entry.libraryKey] || "";
+      out.push(entry);
+    }
+  }
+  return out;
+}
+
+/** ext ブロックテキストからデータフィールドを抽出 */
+function parseExtBlock_(block) {
+  const get = (key, regex) => {
+    const m = block.match(regex);
+    return m ? m[1] : "";
+  };
+  const libraryKey   = get("libraryKey",   /libraryKey:\s*"([^"]+)"/);
+  const extId        = +get("extId",       /extId:\s*(\d+)/);
+  const extNameJa    = get("extNameJa",    /extNameJa:\s*"([^"]+)"/);
+  const skillNameJa  = get("skillNameJa",  /skillNameJa:\s*"([^"]+)"/);
+  const skillIcon    = get("skillIcon",    /skillIcon:\s*"([^"]+)"/);
+  const cost         = +get("cost",        /cost:\s*(\d+)/);
+  const type         = get("type",         /type:\s*"([^"]+)"/);
+  const target       = get("target",       /target:\s*"([^"]+)"/);
+  const caster       = get("caster",       /caster:\s*"([^"]+)"/);
+  if (!libraryKey) return null;
+
+  // effects 配列を抽出: effects: [ { target: "...", text: "..." }, ... ]
+  const effectsBlock = block.match(/effects:\s*\[([\s\S]*?)\]\s*,/);
+  const effects = [];
+  if (effectsBlock) {
+    const inner = effectsBlock[1];
+    const itemRe = /\{\s*target:\s*"([^"]+)"\s*,\s*text:\s*"([^"]+)"\s*\}/g;
+    let em;
+    while ((em = itemRe.exec(inner)) !== null) {
+      effects.push({ target: em[1], text: em[2] });
+    }
+  }
+  return {
+    libraryKey, extId, extNameJa, skillNameJa, skillIcon,
+    cost, type, target, caster, effects,
+  };
+}
+
+/** CARD_RARITIES dict を抽出して { extKey: rarity } を返す */
+function parseCardRarities_(text) {
+  const out = {};
+  // const CARD_RARITIES = { ... }; ブロック
+  const m = text.match(/(?:export\s+)?const\s+CARD_RARITIES\s*=\s*\{([\s\S]*?)\n\};/);
+  if (!m) return out;
+  const inner = m[1];
+  const lineRe = /(\w+):\s*'([a-z]+)'/g;
+  let lm;
+  while ((lm = lineRe.exec(inner)) !== null) {
+    out[lm[1]] = lm[2];
+  }
+  return out;
+}
+
+/** ext エントリ配列を sheet 行 (2 次元配列) に変換
+ *  schema.columns 順序 + effects は最大 3 スロットに展開 */
+function extensionsToRows_(entries) {
+  const rows = [];
+  for (const e of entries) {
+    const row = [
+      e.libraryKey,
+      e.extId,
+      e.extNameJa,
+      e.skillNameJa,
+      e.skillIcon,
+      e.cost,
+      e.type,
+      e.target,
+      e.caster,
+      e.rarity,
+      // effects 最大 3 スロット (target / text 各 2 列ずつ)
+      e.effects[0]?.target || "",
+      e.effects[0]?.text   || "",
+      e.effects[1]?.target || "",
+      e.effects[1]?.text   || "",
+      e.effects[2]?.target || "",
+      e.effects[2]?.text   || "",
+    ];
+    rows.push(row);
+  }
+  return rows;
+}

--- a/tools/gas-sheet-sync/github.gs
+++ b/tools/gas-sheet-sync/github.gs
@@ -78,6 +78,17 @@ function ghFetchRawJson(path, ref) {
   return JSON.parse(res.getContentText());
 }
 
+/** raw.githubusercontent.com から テキストファイル (e.g. cards.js) を取得 */
+function ghFetchRawText(path, ref) {
+  const props = ghProps_();
+  const url = "https://raw.githubusercontent.com/" + props.owner + "/" + props.repo + "/" + (ref || props.base) + "/" + path;
+  const res = UrlFetchApp.fetch(url, { muteHttpExceptions: true });
+  if (res.getResponseCode() !== 200) {
+    throw new Error("raw fetch failed: " + url + " (" + res.getResponseCode() + ")");
+  }
+  return res.getContentText();
+}
+
 /** 指定 ref (branch) の HEAD commit SHA を取得 */
 function ghGetRefSha(ref) {
   const props = ghProps_();

--- a/tools/gas-sheet-sync/menu.gs
+++ b/tools/gas-sheet-sync/menu.gs
@@ -8,6 +8,7 @@ function onOpen() {
   SpreadsheetApp.getUi()
     .createMenu("データ同期")
     .addItem("GitHub から最新を取得 (Pull、全シート)", "pullAllFromGitHub")
+    .addItem("extensions だけ Pull (cards.js から、view 専用)", "pullExtensionsOnly")
     .addSeparator()
     .addSubMenu(
       SpreadsheetApp.getUi().createMenu("Push (シートを選んで PR)")

--- a/tools/gas-sheet-sync/pull.gs
+++ b/tools/gas-sheet-sync/pull.gs
@@ -5,16 +5,15 @@
  * カスタムメニュー「データ同期」→「GitHub から最新を取得 (Pull)」で実行。
  */
 
-/** メニュー: 全シート pull */
+/** メニュー: 全シート pull (extensions も含む) */
 function pullAllFromGitHub() {
   const ui = SpreadsheetApp.getUi();
   try {
     const props = ghProps_();
     const ref = props.base;
     let total = 0;
-    for (const schema of ALL_SCHEMAS) {
-      const json = ghFetchRawJson(schema.jsonPath, ref);
-      const rows = jsonToRows_(json, schema);
+    for (const schema of ALL_PULL_SCHEMAS) {
+      const rows = pullSchemaToRows_(schema, ref);
       writeSheet_(schema, rows);
       total += rows.length;
     }
@@ -28,6 +27,38 @@ function pullAllFromGitHub() {
     ui.alert("Pull 失敗\n" + e.message);
     throw e;
   }
+}
+
+/** メニュー: extensions だけ Pull (cards.js から、view 専用) */
+function pullExtensionsOnly() {
+  const ui = SpreadsheetApp.getUi();
+  try {
+    const props = ghProps_();
+    const ref = props.base;
+    const rows = pullSchemaToRows_(EXTENSIONS_SCHEMA, ref);
+    writeSheet_(EXTENSIONS_SCHEMA, rows);
+    ui.alert(
+      "extensions Pull 完了\n" + rows.length + " 件を取得しました。\n" +
+      "(view 専用シート — このシートは Push 対象外です)\n" +
+      "base ref: " + ref,
+    );
+  } catch (e) {
+    ui.alert("extensions Pull 失敗\n" + e.message);
+    throw e;
+  }
+}
+
+/** schema 1 つ分の行データを取得 (Pull) — JSON / cards.js parse を分岐 */
+function pullSchemaToRows_(schema, ref) {
+  if (schema.sheetName === SHEET_EXT) {
+    // extensions: cards.js を text fetch → parser
+    const text = ghFetchRawText(PATH_CARDS_JS, ref);
+    const entries = parseExtensionsFromCardsJs_(text);
+    return extensionsToRows_(entries);
+  }
+  // 通常 (heroes / ll-extensions): JSON fetch → 配列を行に展開
+  const json = ghFetchRawJson(schema.jsonPath, ref);
+  return jsonToRows_(json, schema);
 }
 
 /** JSON データを 2 次元配列に変換
@@ -55,7 +86,9 @@ function writeSheet_(schema, rows) {
 
   sheet.clear();
   const headers = schema.columns.map(c => c.name);
-  sheet.getRange(1, 1, 1, headers.length).setValues([headers]).setFontWeight("bold").setBackground("#e8eaf6");
+  // Pull-only シートはヘッダ色を変えて視覚的に区別 (赤系 = 編集無効)
+  const headerColor = schema.pullOnly ? "#fce4ec" : "#e8eaf6";
+  sheet.getRange(1, 1, 1, headers.length).setValues([headers]).setFontWeight("bold").setBackground(headerColor);
   sheet.setFrozenRows(1);
 
   if (rows.length > 0) {

--- a/tools/gas-sheet-sync/schema.gs
+++ b/tools/gas-sheet-sync/schema.gs
@@ -7,10 +7,12 @@
 
 const SHEET_HEROES   = "heroes";
 const SHEET_LL_EXT   = "ll-extensions";
+const SHEET_EXT      = "extensions";
 const SHEET_META     = "_meta";   // sync 状態 (lastSyncedSha, lastPullAt 等) を置く隠しシート
 
-const PATH_HEROES = "prototype/data/heroes.json";
-const PATH_LL_EXT = "prototype/data/ll-extensions.json";
+const PATH_HEROES   = "prototype/data/heroes.json";
+const PATH_LL_EXT   = "prototype/data/ll-extensions.json";
+const PATH_CARDS_JS = "prototype/js/cards.js";  // extensions の正本 (Pull-only)
 
 /** heroes.json の列スキーマ */
 const HEROES_SCHEMA = {
@@ -45,7 +47,39 @@ const LL_EXT_SCHEMA = {
   ],
 };
 
+/** extensions (cards.js から parse、Pull-only)
+ *  cards.js には play() 等の JS 関数本体が含まれるため Push は危険。
+ *  本シートは「カードカタログ閲覧用」と位置付ける。
+ *  値編集してもボタンを押しても Push 対象には含まれない。 */
+const EXTENSIONS_SCHEMA = {
+  sheetName: SHEET_EXT,
+  jsonPath: PATH_CARDS_JS,         // 表示用、実際の fetch は ghFetchRawText 経由
+  pullOnly: true,
+  columns: [
+    { name: "libraryKey",     type: "string" },
+    { name: "extId",          type: "int" },
+    { name: "extNameJa",      type: "string" },
+    { name: "skillNameJa",    type: "string" },
+    { name: "skillIcon",      type: "string" },
+    { name: "cost",           type: "int" },
+    { name: "type",           type: "enum", options: ["atk", "skl", "power"] },
+    { name: "target",         type: "string" },
+    { name: "caster",         type: "string" },
+    { name: "rarity",         type: "enum", options: ["common", "uncommon", "rare", "epic", "legendary"] },
+    { name: "effect_1_target", type: "string" },
+    { name: "effect_1_text",   type: "string" },
+    { name: "effect_2_target", type: "string" },
+    { name: "effect_2_text",   type: "string" },
+    { name: "effect_3_target", type: "string" },
+    { name: "effect_3_text",   type: "string" },
+  ],
+};
+
+/** Pull/Push 両対応の標準 schemas (push.gs が使う) */
 const ALL_SCHEMAS = [HEROES_SCHEMA, LL_EXT_SCHEMA];
+
+/** Pull のみ対応 schemas (extensions 等) を含む全 schema 一覧 (pull.gs が使う) */
+const ALL_PULL_SCHEMAS = [HEROES_SCHEMA, LL_EXT_SCHEMA, EXTENSIONS_SCHEMA];
 
 /** value を type に応じて型変換 (sheet → JSON 用) */
 function coerceValue_(value, type) {


### PR DESCRIPTION
## Summary

LL extensions のみだった spreadsheet 同期に、通常 extensions も追加。cards.js には `play()` 等の JS 関数本体が含まれるため Push (書き戻し) は危険なので **Pull-only (view 専用)** で実装。テスター が**カードカタログを spreadsheet 上で閲覧 / フィルタリング / ソート**できる。

## 機能

| 操作 | 内容 |
|---|---|
| **メニュー [データ同期] → [extensions だけ Pull (cards.js から、view 専用)]** | extensions シートのみ更新 |
| **メニュー [データ同期] → [GitHub から最新を取得 (Pull、全シート)]** | heroes / ll-extensions / **extensions** をまとめて Pull |
| **Push 系メニュー** | extensions は対象外 (`push.gs` の `ALL_SCHEMAS` に未含) |

## シート列構成

| 列 | 説明 |
|---|---|
| `libraryKey` | "ext1234" |
| `extId` | 1234 |
| `extNameJa` / `skillNameJa` | カード名 / スキル名 |
| `skillIcon` | アイコン filename |
| `cost` | エナジーコスト |
| `type` | atk / skl / power |
| `target` | TargetSpec |
| `caster` | CasterRole |
| `rarity` | common / uncommon / rare / epic / legendary (CARD_RARITIES から結合) |
| `effect_1_target` / `effect_1_text` | effects[0] |
| `effect_2_target` / `effect_2_text` | effects[1] |
| `effect_3_target` / `effect_3_text` | effects[2] |

(effects は最大 3 スロットまで展開。それ以上ある場合は途切れる)

ヘッダ背景色は **赤系 (#fce4ec)** にし、編集できないことを視覚的に区別 (他シートは青系 #e8eaf6)。

## ファイル構成

| ファイル | 役割 |
|---|---|
| `tools/gas-sheet-sync/extensions-parser.gs` (新規) | cards.js から正規表現で各 ext ブロックを抽出 + CARD_RARITIES 結合 |
| `tools/gas-sheet-sync/github.gs` | `ghFetchRawText(path, ref)` を新設 (text fetch 用) |
| `tools/gas-sheet-sync/schema.gs` | `EXTENSIONS_SCHEMA` を追加 (`pullOnly: true`)、`ALL_PULL_SCHEMAS` 新設 |
| `tools/gas-sheet-sync/pull.gs` | `pullSchemaToRows_()` 分岐 / `pullExtensionsOnly()` 単独関数 / `writeSheet_()` で `pullOnly` ヘッダ色対応 |
| `tools/gas-sheet-sync/menu.gs` | 「extensions だけ Pull」メニュー項目追加 |
| `tools/gas-sheet-sync/README.md` | extensions シート仕様を追記 |

## 動作確認 (ローカル)

cards.js (約 22000 行) から **907 件** の ext を抽出 (PR #89 で削除した 13 件を除く合計と一致)。rarity 内訳:

| rarity | 件数 |
|---|---|
| common | 173 |
| uncommon | 190 |
| rare | 182 |
| epic | 185 |
| legendary | 177 |
| **合計** | **907** |

最初の 3 件のサンプル: ext1001 ノービスブレード / ext1002 ノービスマスケット / ext1003 ノービスペン — 全フィールドが正しく抽出された。

## Test plan

- [ ] スプレッドシートに最新の `extensions-parser.gs` を貼り付け、保存 → リロード
- [ ] メニュー [データ同期] → [extensions だけ Pull] 実行
- [ ] `extensions` シートが新規作成され 907 件入る (ヘッダ赤系)
- [ ] 各列が正しく入っている (libraryKey / extId / 名前 / cost / type / target / caster / rarity / effects)
- [ ] [全シート Pull] 実行 → heroes + ll-extensions + extensions すべて pull される
- [ ] Push メニュー (heroes だけ Push 等) が extensions に作用しない (ALL_SCHEMAS に extensions が無いため、PR が立たない)
- [ ] extensions シートのセルを編集 → [Push] しても extensions の編集は GitHub に行かない (heroes/ll-ext のみ反映)

## 残候補 (次以降)

- A. enemies (intentRota 列展開) — Pull/Push 両対応、今回の design pattern (parser + schema 拡張) を踏襲して実装可
- B. bosses (intentRota + phases) — A と同じだが phases 行展開が追加
- D. ヒーロー passive 編集 (passives-generated.js 同期) — codemod アーキテクチャ判断あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)