### PR TITLE
fix(combat): HP 回復で hpMax を超えるバグを修正

### DIFF
--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -766,10 +766,12 @@ function getPlayerAttackTargetEnemy(s) {
   return foremostAlive(s.enemies) || s.enemies[0] || null;
 }
 
-/** 敵 HP を更新し、必要に応じて legacy フィールドを同期 */
+/** 敵 HP を更新し、必要に応じて legacy フィールドを同期。HP は [0, hpMax] にクランプ。 */
 function applyHpDeltaToEnemy(s, enemy, delta) {
   if (!enemy) return;
-  enemy.hp = Math.max(0, (enemy.hp ?? 0) + delta);
+  const newHp = (enemy.hp ?? 0) + delta;
+  const cap = enemy.hpMax ?? newHp;
+  enemy.hp = Math.max(0, Math.min(cap, newHp));
   if (enemy.hp <= 0) enemy.alive = false;
   if (s.enemies && enemy === s.enemies[0]) {
     s.enemyHp = enemy.hp;
@@ -873,11 +875,14 @@ function getEnemyAttackTargetHero(s) {
   return tgt || s.heroes[0] || null;
 }
 
-/** ヒーローユニットの hp / alive を更新し、必要に応じて legacy フィールドを同期する。 */
+/** ヒーローユニットの hp / alive を更新し、必要に応じて legacy フィールドを同期する。
+ *  HP は [0, hpMax] にクランプ (回復で上限超えを防止)。 */
 function applyHpDeltaToHero(s, hero, delta) {
   if (!hero) return;
   const wasAlive = hero.alive !== false && (hero.hp ?? 0) > 0;
-  hero.hp = Math.max(0, (hero.hp ?? 0) + delta);
+  const newHp = (hero.hp ?? 0) + delta;
+  const cap = hero.hpMax ?? newHp;
+  hero.hp = Math.max(0, Math.min(cap, newHp));
   if (hero.hp <= 0) hero.alive = false;
   // heroes[0] (前衛) なら legacy combat.playerHp と同期
   if (s.heroes && hero === s.heroes[0]) {


### PR DESCRIPTION
## Summary

ユーザ報告: 「HP が上限超えて回復する」

## 原因

\`applyHpDeltaToHero\` / \`applyHpDeltaToEnemy\` (passive runtime の heal handler が経由するベースヘルパ) は **下限 0 のクランプはしていたが上限 (hpMax) のクランプが抜けていた**:

\`\`\`js
// Before
hero.hp = Math.max(0, (hero.hp ?? 0) + delta);  // hpMax 超え可能
\`\`\`

\`\`\`js
// After
const newHp = (hero.hp ?? 0) + delta;
const cap = hero.hpMax ?? newHp;
hero.hp = Math.max(0, Math.min(cap, newHp));   // [0, hpMax] にクランプ
\`\`\`

\`healPlayerFromIntSkill\` / 敵 \`healSelf\` 等の独自パスは元々 \`Math.min(hpMax, ...)\` で capping 済み — 今回の修正は **passive runtime 経由の回復** が走るベースヘルパ側を堅牢化。

## Test plan

- [ ] 満タン状態で回復系カード (ノービスペン等) を使用 → HP は hpMax のまま増えない
- [ ] HP 半分の状態から大回復 → hpMax 上限で止まる
- [ ] passive 回復系 (ranmaru / daejanggeum 等) を発動させて HP 上限を超えないことを確認
- [ ] 敵の healSelf intent (boss-hl 等) も hpMax 上限で止まる

🤖 Generated with [Claude Code](https://claude.com/claude-code)