### PR TITLE
balance: シート同期 extensions (20260503-003813)

### DIFF
--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -94,7 +94,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "atk",
-      target: "enemy.foremost",
+      target: "enemy.all",
       caster: "highest_int",
       // SPEC-006: auto-derived effects (review needed: no)
       effects: [
@@ -259,7 +259,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "skl",
-      target: "enemy.foremost",
+      target: "enemy.all",
       caster: "highest_int",
       // SPEC-006: auto-derived effects (review needed: no)
       effects: [
@@ -365,7 +365,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "atk",
-      target: "enemy.foremost",
+      target: "enemy.all",
       caster: "highest_int",
       // SPEC-006: 攻撃 + 敵 INT ダウン
       effects: [
@@ -476,7 +476,7 @@ function makeCardLibrary(clog, api) {
       skillIcon: "int.png",
       cost: 1,
       type: "atk",
-      target: "enemy.foremost",
+      target: "enemy.all",
       caster: "highest_int",
       // SPEC-006: auto-derived effects (review needed: no)
       effects: [


### PR DESCRIPTION
Spreadsheet (extensions シート) からの自動 PR — top-level literal フィールドのみ更新

## 変更内訳
- 変更カード数: 4
- 総フィールド変更数: 906

## 対象フィールド (Push 対象)
extNameJa / skillNameJa / skillIcon / cost / type / target / caster / rarity / effect_*_text

## 対象外 (cards.js 直接編集)
- libraryKey / extId (識別子)
- effect_*_target (play() 連動のため)
- ダメージ係数 (play() / effectSummaryLines() / previewLines() 内 hardcoded)

## 実行情報
- 実行ユーザ: bearko.miyamoto@gmail.com
- 実行時刻: 2026-05-02T15:38:18.566Z
- base SHA: d701fa3db7c47b22a0bb8eaa7bc70f3a4a9ceb75
- 元 pull SHA: d701fa3db7c47b22a0bb8eaa7bc70f3a4a9ceb75
