### PR TITLE
balance: シート同期 extensions (20260503-010623)

### DIFF
--- a/prototype/js/cards.js
+++ b/prototype/js/cards.js
@@ -160,7 +160,7 @@ function makeCardLibrary(clog, api) {
       cost: 1,
       type: "skl",
       target: "self",
-      caster: "rearmost",
+      caster: "foremost",
       // SPEC-006: auto-derived effects (review needed: no)
       effects: [
         { target: "self", text: "PHY +2" },


### PR DESCRIPTION
Spreadsheet (extensions シート) からの自動 PR — top-level literal フィールドのみ更新

## 変更内訳
- 変更カード数: 1
- 総フィールド変更数: 903

## 対象フィールド (Push 対象)
extNameJa / skillNameJa / skillIcon / cost / type / target / caster / rarity / effect_*_text

## 対象外 (cards.js 直接編集)
- libraryKey / extId (識別子)
- effect_*_target (play() 連動のため)
- ダメージ係数 (play() / effectSummaryLines() / previewLines() 内 hardcoded)

## 実行情報
- 実行ユーザ: bearko.miyamoto@gmail.com
- 実行時刻: 2026-05-02T16:06:27.268Z
- base SHA: d29b7b6a03b1ad5aa1908496c74b32658ea077e0
- 元 pull SHA: d29b7b6a03b1ad5aa1908496c74b32658ea077e0
