### PR TITLE
fix: ランクアップ後の cost / 効果表示 + ショップ重複描画を修正

### DIFF
--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -2081,7 +2081,9 @@ function startCombatFromMapNode(node) {
     }
   }
 
-  combat.drawPile = shuffle(combat.deck.map((c) => copyCard(c.libraryKey)));
+  // β1: ランクアップ済みカードの per-instance フィールド (cost override 等) を保持するため
+  // copyCard で library から再生成せず、既存インスタンスを shallow clone する。
+  combat.drawPile = shuffle(combat.deck.map((c) => ({ ...c })));
   showView("combat");
   startBgmCombat();
 
@@ -6119,9 +6121,22 @@ function showOwnedDeckPeek(def) {
     playerHpMax: runState?.playerHpMax ?? LEADER.hpMax,
     playerGuard: 0, playerShield: 0, energyMax: 3, energy: 3,
   };
-  const lines =
-    typeof def.previewLines === "function" ? def.previewLines(mockS) :
-    typeof def.effectSummaryLines === "function" ? def.effectSummaryLines(mockS) : [];
+  // ランクアップでエフェクトが増えるカードは effects[] 配列に全件入っているので、
+  // それを優先で表示する (previewLines は単独 line のみのカードがあり 2/3 が欠落する)。
+  let linesHtml = "";
+  if (Array.isArray(def.effects) && def.effects.length > 0) {
+    linesHtml = def.effects.map(e => {
+      const lbl = targetLabelText(e.target) || e.target || "";
+      const colorVar = targetColorVar(e.target) || "--text";
+      const simplified = simplifyEffectText(e.text || "");
+      return `<p><span class="opc-target" style="color: var(${colorVar})">[${escapeHtml(lbl)}]</span> ${escapeHtml(simplified)}</p>`;
+    }).join("");
+  } else {
+    const lines =
+      typeof def.previewLines === "function" ? def.previewLines(mockS) :
+      typeof def.effectSummaryLines === "function" ? def.effectSummaryLines(mockS) : [];
+    linesHtml = lines.map(l => `<p>${escapeHtml(simplifyEffectText(l))}</p>`).join("");
+  }
   const rarity = CARD_RARITIES[def.libraryKey] || "common";
   // SPEC-006 Phase 4h: caster ロールを peek にも表示
   const roleKey = def.caster || "foremost";
@@ -6136,7 +6151,7 @@ function showOwnedDeckPeek(def) {
         <span>${RARITY_LABEL[rarity] || rarity}</span>
         <span class="opc-caster">使い手: ${escapeHtml(roleLabel)}</span>
       </div>
-      <div class="opc-lines">${lines.map(l => `<p>${escapeHtml(simplifyEffectText(l))}</p>`).join("")}</div>
+      <div class="opc-lines">${linesHtml}</div>
       <button type="button" class="opc-close">閉じる</button>
     </div>
   `;
@@ -6164,9 +6179,15 @@ function openOwnedDeckOverlay() {
   }
 
   // ソート: シリーズキー → レアリティ → libraryKey（カード単位）
+  // ランクアップ済みカードの per-instance cost override を保持するため、
+  // CARD_LIBRARY ベースのまま全置換せず instance 値を上書きで残す。
   const sorted = cards
     .filter(c => c && c.libraryKey)
-    .map(c => CARD_LIBRARY[c.libraryKey] || c)
+    .map(c => {
+      const def = CARD_LIBRARY[c.libraryKey];
+      if (!def) return c;
+      return { ...def, cost: c.cost ?? def.cost };
+    })
     .sort((a, b) => {
       const sa = deckSeriesKey(a.libraryKey);
       const sb = deckSeriesKey(b.libraryKey);
@@ -6648,6 +6669,9 @@ function openShop() {
 
   const list = document.getElementById("shopList");
   list.innerHTML = "";
+  // 入店ごとに前回追加した「カード破棄」「ランクアップ」セクションが
+  // shopList の親 (shopView) に積み重なるのを防ぐため、ここで一掃する。
+  list.parentElement.querySelectorAll(".shop-remove-section").forEach(el => el.remove());
 
   // カードプレビュー用モックステート（現在のランステートを参照）
   ensureRunState();


### PR DESCRIPTION
## Summary

報告された 3 件のバグを 1 PR で修正します。

### 1. コスト据え置きがバトルに反映されていない

**症状:** クラフト打ち直し / ショップランクアップでコスト据え置きランクアップしたエクステが、バトルではデータベース準拠（CARD_LIBRARY のリテラル）コストで判定されていた。

**原因:** [main.js:2084](prototype/js/main.js#L2084) で
\`\`\`js
combat.drawPile = shuffle(combat.deck.map((c) => copyCard(c.libraryKey)));
\`\`\`
となっており、\`copyCard\` が CARD_LIBRARY から再生成。\`combat.deck\` には instance level の cost override が乗っていたが、ここで剥がれていた。

**修正:** shallow spread に変更し、per-instance フィールドを保持。
\`\`\`js
combat.drawPile = shuffle(combat.deck.map((c) => ({ ...c })));
\`\`\`

### 2. ランクアップ後の効果 2/3 がデッキポップアップに出ない

**症状:** スクショの「真夜中のスタールビー（レジェンド）」では \`effects[]\` に 3 行（PHYダメ・出血・ドロー）あるはずが、ポップアップでは PHY ダメ 1 行のみ表示。

**原因:** [main.js:6122-6124](prototype/js/main.js#L6122) で \`previewLines()\` を優先利用しているが、本カードの \`previewLines\` はダメージ 1 行しか返さないため effects 2/3 が消えていた。

**修正:** \`effects[]\` 配列があればそちらを優先 (target pill 付き)、無ければ従来の previewLines / effectSummaryLines にフォールバック（\`buildRewardPickButton\` と同じ方針）。

加えて [main.js:6169](prototype/js/main.js#L6169) の sorted 構築で
\`\`\`js
.map(c => CARD_LIBRARY[c.libraryKey] || c)
\`\`\`
が cost override を消していたので、\`{ ...def, cost: c.cost ?? def.cost }\` に変更し instance cost を保持。

### 3. ショップ入店毎に「ランクアップ」「カード破棄」アイコンが増殖

**症状:** ショップに入店し直すたびにメニューアイコンが 1 → 2 → 3 と積まれる。

**原因:** [main.js:6743, 6766](prototype/js/main.js#L6743) で \`removeSection\` / \`upgradeSection\` を \`list.parentElement\` (= shopView) に append しているが、入店時の clear は \`shopList.innerHTML = \"\"\` だけで親側のセクションが残留。

**修正:** \`openShop\` 冒頭で \`.shop-remove-section\` を一掃。
\`\`\`js
list.parentElement.querySelectorAll(\".shop-remove-section\").forEach(el => el.remove());
\`\`\`

## Test plan
- [ ] Common ext を 2 連続でランクアップ (Common → Uncommon → Rare 等) し、バトルでも cost が Common 値のままであることを確認
- [ ] レジェンドまでランクアップしたカードを「デッキを見る」で開き、popup に effect 2/3 が出ることを確認 (target pill 付きで)
- [ ] ショップに入店 → 立ち去る → 別ノードからショップ入店、を繰り返してアイコンが累積しないことを確認
- [ ] 報酬画面 / クラフト / ショップ商品の通常表示が破綻していないこと（buildRewardPickButton 経路は変更なしなので OK のはず）