### PR TITLE
chore: タイトル画面の「ベータ１版」を削除し他箇所を Ver.1.0.0 に差し替え

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>MyCryptoTactics — ベータ１版</title>
+  <title>MyCryptoTactics — Ver.1.0.0</title>
   <meta name="description" content="My Crypto Heroes の偉人たち × ローグライク × カードバトルのファンメイドブラウザゲーム。" />
 
   <!-- favicon -->
@@ -11,7 +11,7 @@
 
   <!-- Open Graph / Twitter Card (X リンクプレビュー用) -->
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="MyCryptoTactics — ベータ１版" />
+  <meta property="og:title" content="MyCryptoTactics — Ver.1.0.0" />
   <meta property="og:description" content="My Crypto Heroes の偉人たち × ローグライク × カードバトル。スマホ・PC で遊べるブラウザゲーム。" />
   <meta property="og:url" content="https://mycryptotactics.vercel.app/" />
   <meta property="og:image" content="https://mycryptotactics.vercel.app/og-image.png" />
@@ -19,7 +19,7 @@
   <meta property="og:image:height" content="1536" />
   <meta property="og:site_name" content="MyCryptoTactics" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="MyCryptoTactics — ベータ１版" />
+  <meta name="twitter:title" content="MyCryptoTactics — Ver.1.0.0" />
   <meta name="twitter:description" content="My Crypto Heroes 偉人 × ローグライク × カードバトル。" />
   <meta name="twitter:image" content="https://mycryptotactics.vercel.app/og-image.png" />
 
@@ -2576,7 +2576,6 @@
   <!-- ── Title Screen ── -->
   <div id="titleView" class="title-screen" role="button" aria-label="ゲームを始める" tabindex="0">
     <img class="title-logo" src="./MCT_logo.jpg" alt="MyCryptoTactics" />
-    <p class="title-alpha">ベータ１版</p>
     <p class="title-press">Press to Start</p>
   </div>
 
@@ -2924,7 +2923,7 @@
   </div>
 
   <footer>
-    <span class="footer-meta">MyCryptoTactics ベータ１版 · 非営利のファン制作</span>
+    <span class="footer-meta">MyCryptoTactics Ver.1.0.0 · 非営利のファン制作</span>
     <span class="footer-credit">
       キャラクター画像 / BGM / SE は <strong>My Crypto Heroes (MCH Co., Ltd.)</strong> に帰属します。
       利用条件・権利表記・二次創作ガイドラインは
@@ -3084,7 +3083,7 @@
             <li><strong>?</strong> — ランダム（その時点の生存者から無作為に選択）。</li>
             <li><strong>PHY↑ / HP↓</strong> 等 — そのステータスが<strong>最も高い / 低い</strong>対象を選択。</li>
           </ul>
-          <p style="font-size:0.78rem;color:var(--muted)">※ パーティ編成（3 人 vs 3 人）はベータ１版から有効です。前衛・中衛・後衛の並びはタイトルから入って編成画面で確認できます。</p>
+          <p style="font-size:0.78rem;color:var(--muted)">※ パーティ編成（3 人 vs 3 人）はVer.1.0.0から有効です。前衛・中衛・後衛の並びはタイトルから入って編成画面で確認できます。</p>
         </section>
         <section class="help-page" data-help-page="battle">
           <h3>バトルロジック（概要）</h3>


### PR DESCRIPTION
## Summary

- タイトル画面（[index.html](prototype/index.html#L2577) の `#titleView`）から `<p class=\"title-alpha\">ベータ１版</p>` を削除
- 残り 4 箇所の「ベータ１版」表記を **Ver.1.0.0** に置換

## 変更箇所

| 行 | 種類 | 変更後 |
|---|---|---|
| 6 | `<title>` | `MyCryptoTactics — Ver.1.0.0` |
| 14 | og:title | `MyCryptoTactics — Ver.1.0.0` |
| 22 | twitter:title | `MyCryptoTactics — Ver.1.0.0` |
| 2926 | フッター | `MyCryptoTactics Ver.1.0.0 · 非営利のファン制作` |
| 3086 | 編成画面案内文 | `…はVer.1.0.0から有効です。` |

## Test plan
- [ ] タイトル画面でロゴ下に「ベータ１版」が表示されない（「Press to Start」のみ）
- [ ] ブラウザタブのタイトルが `MyCryptoTactics — Ver.1.0.0`
- [ ] フッターが `MyCryptoTactics Ver.1.0.0 · 非営利のファン制作`
- [ ] X / Discord 等で URL シェア時のプレビューカードが Ver.1.0.0 表示