### PR TITLE
feat(i18n): header lang toggle + craft + peek tooltip + clog post-process

### DIFF
--- a/prototype/data/i18n/ui.json
+++ b/prototype/data/i18n/ui.json
@@ -323,5 +323,61 @@
   "abs.scoreMult":             { "ja": "スコア倍率（敵HP×敵ダメ ÷ 自HP×自ダメ）", "en": "Score mult. (eHP×eDmg ÷ sHP×sDmg)" },
   "abs.start":                 { "ja": "この設定で開始", "en": "Start with these settings" },
 
-  "gameover.clear.msg":        { "ja": "全 node クリアおめでとうございます！あなたは最高ですよ〜！", "en": "All nodes cleared — congratulations! You're the best!" }
+  "gameover.clear.msg":        { "ja": "全 node クリアおめでとうございます！あなたは最高ですよ〜！", "en": "All nodes cleared — congratulations! You're the best!" },
+
+  "peek.guard": {
+    "ja": "<strong>ガード</strong> — ターン中、PHY/INT ダメージを数値分だけ先に吸収（味方はターン開始で 0）。",
+    "en": "<strong>Guard</strong> — soaks PHY/INT DMG this turn (allies reset to 0 at turn start)."
+  },
+  "peek.shield": {
+    "ja": "<strong>シールド</strong> — 特殊ダメージ（最大 HP 割合など）のみ吸収。PHY/INT 通常攻撃には無効。",
+    "en": "<strong>Shield</strong> — soaks special DMG only (e.g. max-HP %). No effect on normal PHY/INT."
+  },
+  "peek.energy": {
+    "ja": "<strong>⚡ エナジー</strong> — ターンで使える行動コスト。次ターン開始時に最大まで回復。",
+    "en": "<strong>⚡ Energy</strong> — action cost per turn. Refills to max next turn."
+  },
+  "peek.draw": {
+    "ja": "<strong>ドロー</strong> — 山札から手札へカードを引く。山が空なら捨て札をシャッフルして山にする。",
+    "en": "<strong>Draw</strong> — pull a card from the deck; reshuffles discard if empty."
+  },
+  "peek.phy": {
+    "ja": "<strong>PHY</strong> — 物理攻撃の基礎値。PHY 依存スキルのダメージに使う。",
+    "en": "<strong>PHY</strong> — base for physical attacks; feeds PHY-skill DMG."
+  },
+  "peek.int": {
+    "ja": "<strong>INT</strong> — 知略の基礎値。INT 攻撃や回復係数に関わる。",
+    "en": "<strong>INT</strong> — base for magic attacks and the heal coefficient."
+  },
+  "peek.agi": {
+    "ja": "<strong>AGI</strong> — このプロトでは主にクリティカル率に反映。",
+    "en": "<strong>AGI</strong> — mainly feeds the crit rate in this prototype."
+  },
+  "peek.hp": {
+    "ja": "<strong>HP</strong> — 0 で敗北。回復は最大値を超えない。",
+    "en": "<strong>HP</strong> — 0 = defeat. Heal can't exceed max."
+  },
+
+  "badge.energyShort":         { "ja": "⚡不足", "en": "⚡ low" },
+  "badge.energyTip":           { "ja": "エナジーが {need} 必要ですが {have} しかありません", "en": "Needs {need} energy; only {have} available" },
+  "badge.casterShort":         { "ja": "👤不在", "en": "👤 none" },
+  "badge.casterTip":           { "ja": "キャスター「{role}」が解決できません（該当ヒーロー全員死亡）", "en": "No caster for role “{role}” (all matching heroes are down)" },
+
+  "craft.title":               { "ja": "クラフト", "en": "Craft" },
+  "craft.sub":                 { "ja": "エクステンションを獲得するか、デッキを強化しましょう", "en": "Pick up an Extension or rank up your deck." },
+  "craft.get.title":           { "ja": "エクステ獲得", "en": "Get Extension" },
+  "craft.get.desc":            { "ja": "累積カードプールからカードを3枚提示します。1枚をデッキに追加できます。", "en": "Pick 1 of 3 cards drawn from the cumulative pool to add to your deck." },
+  "craft.get.button":          { "ja": "獲得する", "en": "Get" },
+  "craft.get.pick":            { "ja": "1枚を選んでデッキに追加します", "en": "Pick one to add to your deck" },
+  "craft.reroll.title":        { "ja": "打ち直し", "en": "Reroll" },
+  "craft.reroll.desc":         { "ja": "デッキ内のノービスカードを1枚選んでエリートにランクアップします。", "en": "Pick one Novice card from your deck and rank it up to Elite." },
+  "craft.reroll.button":       { "ja": "打ち直す", "en": "Reroll" },
+  "craft.reroll.pick":         { "ja": "ランクアップするカードを選んでください（ノービス → エリート）", "en": "Pick a card to rank up (Novice → Elite)" },
+  "craft.reroll.empty":        { "ja": "アップグレード可能なノービスカードがありません", "en": "No Novice cards eligible for upgrade" },
+  "craft.upgrade.button":      { "ja": "このカードを強化", "en": "Upgrade this card" },
+  "craft.backMap":             { "ja": "← マップに戻る", "en": "← Back to map" },
+  "craft.skip":                { "ja": "スキップ", "en": "Skip" },
+
+  "clog.craftGet":             { "ja": "クラフト獲得: {name}", "en": "Crafted: {name}" },
+  "clog.craftUpgrade":         { "ja": "打ち直し: {from} → {to} (コスト {cost} 据え置き)", "en": "Reroll: {from} → {to} (cost {cost} preserved)" }
 }

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -193,6 +193,29 @@
     .btn-help:hover { border-color: var(--accent); background: #2a2438; }
     .btn-help:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
+    /* ── 常設ヘッダー言語トグル (map / combat ヘッダー共通) ── */
+    .btn-lang-hd {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 32px;
+      height: 22px;
+      padding: 0 0.4rem;
+      border-radius: 4px;
+      border: 1px solid #5b4d8a;
+      background: rgba(155,127,210,0.10);
+      color: #c8b6e6;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      cursor: pointer;
+      line-height: 1;
+      flex-shrink: 0;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+    }
+    .btn-lang-hd:hover { background: rgba(155,127,210,0.25); border-color: #9b7fd2; color: #fff; }
+    .btn-lang-hd:focus-visible { outline: 2px solid #9b7fd2; outline-offset: 2px; }
+
     /* SPEC-007: ヘッダー右端のランキングボタン (map / combat 共通) */
     .btn-ranking {
       width: 32px; height: 32px; padding: 2px;
@@ -2650,6 +2673,7 @@
       <img class="header-reg-icon" id="headerRegIconMap" data-i18n-attr-alt="res.regulation.alt" data-i18n-attr-title="res.regulation.alt" alt="レギュレーション" title="レギュレーション" />
       <button type="button" class="btn-ranking" id="btnRankingOpenMap" data-i18n-attr-aria-label="res.ranking.aria" data-i18n-attr-title="res.ranking.alt" aria-label="ランキングを表示" title="ランキング"><img src="./ranking_icon.png" data-i18n-attr-alt="res.ranking.alt" alt="ランキング" /></button>
       <button type="button" class="btn-help" id="btnHelpOpen" data-i18n-attr-aria-label="res.help.aria" data-i18n-attr-title="res.help.title" aria-label="ヘルプを開く" title="ヘルプ">?</button>
+      <button type="button" class="btn-lang-hd" id="btnLangToggleMap" data-i18n-attr-aria-label="lang.toggle.label" data-i18n-attr-title="lang.toggle.label" aria-label="言語 / Language" title="言語 / Language">JP</button>
     </div>
 
     <div id="mapView" class="panel" style="position:relative">
@@ -2686,6 +2710,7 @@
           <button type="button" class="btn-ranking btn-ranking-combat" id="btnRankingOpenCombat" data-i18n-attr-aria-label="res.ranking.aria" data-i18n-attr-title="res.ranking.alt" aria-label="ランキングを表示" title="ランキング"><img src="./ranking_icon.png" data-i18n-attr-alt="res.ranking.alt" alt="ランキング" /></button>
           <button type="button" class="btn-icon-hd" id="btnSettingsOpen" data-i18n-attr-aria-label="res.settings" data-i18n-attr-title="res.settings" aria-label="設定" title="設定">⚙</button>
           <button type="button" class="btn-icon-hd" id="btnHelpOpenCombat" data-i18n-attr-aria-label="res.help.title" data-i18n-attr-title="res.help.title" aria-label="ヘルプ" title="ヘルプ">?</button>
+          <button type="button" class="btn-lang-hd" id="btnLangToggleCombat" data-i18n-attr-aria-label="lang.toggle.label" data-i18n-attr-title="lang.toggle.label" aria-label="言語 / Language" title="言語 / Language">JP</button>
         </div>
       </div>
 

--- a/prototype/js/i18n.js
+++ b/prototype/js/i18n.js
@@ -85,6 +85,14 @@ function _lookupEn(table, id) {
   return table[String(id)] || null;
 }
 
+/** lang に関係なく EN 名を返すローレベルルックアップ。
+ *  名前置換マップ構築のように「現在言語に依存させたくない」初期化処理から使う。 */
+export function getEnHeroName(id)   { return _lookupEn(_heroes, id)?.name        || null; }
+export function getEnEnemyName(id)  { return _lookupEn(_enemies, id)?.name       || null; }
+export function getEnExtName(id)    { return _lookupEn(_exts, id)?.name          || null; }
+export function getEnExtSkill(id)   { return _lookupEn(_exts, id)?.skillName     || null; }
+export function getEnPassiveName(id){ return _lookupEn(_heroes, id)?.passiveName || null; }
+
 /** Hero name. Returns JA name if EN unavailable. */
 export function tHero(heroId, jaName) {
   if (_lang === "ja") return jaName ?? "";
@@ -174,9 +182,13 @@ const RUNTIME_REPLACEMENTS = [
   [/INT最高/g, "Highest INT"],
   [/HP最高/g,  "Highest HP"],
   [/AGI最高/g, "Highest AGI"],
+  // 「ダメージ」を先に置換 → 残った「ダメ」だけを後で潰す。
+  // 旧版は `/ダメ\b/g` を使っていたが JS の \b は非 ASCII の境界に発火しないため
+  // 「25-30% ダメ」が翻訳されないままだった (shop カード券面で再発)。
+  [/ダメージ/g, "DMG"],
   [/PHYダメ/g, "PHY DMG"],
   [/INTダメ/g, "INT DMG"],
-  [/ダメ\b/g, "DMG"],
+  [/ダメ/g, "DMG"],
   [/PHY攻撃/g, "PHY attack"],
   [/INT攻撃/g, "INT attack"],
   [/出血/g, "Bleed"],
@@ -316,26 +328,71 @@ export function tCasterLabel(role, jaLabel) {
  * 通すので、ここはテンプレ部分のみカバー。
  */
 const COMBAT_LOG_REPLACEMENTS = [
-  // 角括弧つきヒーロー名・カード名は EN モードでは括弧記号もそのままで OK
-  [/\bダメ\b/g, "DMG"],
-  [/\bダメージ\b/g, "DMG"],
+  // ── 角括弧つきヒーロー名・カード名 [XX] のラッパ
   [/が\【/g, " used ["],
   [/\】を使用/g, "]"],
-  [/\】 ?発動/g, "] triggered"],
-  [/発動！/g, "triggered!"],
+  [/\】 ?発動！?/g, "] triggered!"],
+  [/【/g, "["],
+  [/】/g, "]"],
+  // ── 状態異常 / 効果適用
   [/に出血\s*[×x]\s*(\d+)/g, " → Bleed×$1"],
   [/に毒\s*[×x]\s*(\d+)/g, " → Poison×$1"],
+  [/出血\s*[×x]\s*(\d+)\s*追加/g, "Bleed×$1 added"],
+  [/出血\s*[×x]\s*(\d+)\s*付与（敵全体）/g, "Bleed×$1 → all enemies"],
+  [/出血\s*[×x]\s*(\d+)\s*付与（敵）/g, "Bleed×$1 → enemy"],
+  [/出血\s*[×x]\s*(\d+)\s*付与/g, "Bleed×$1 applied"],
+  [/毒\s*[×x]\s*(\d+)\s*付与（敵全体）/g, "Poison×$1 → all enemies"],
+  [/毒\s*[×x]\s*(\d+)\s*付与（敵）/g, "Poison×$1 → enemy"],
+  [/毒\s*[×x]\s*(\d+)\s*付与/g, "Poison×$1 applied"],
   [/出血ダメージ\s*(\d+)/g, "Bleed dmg $1"],
   [/毒ダメージ\s*(\d+)/g, "Poison dmg $1"],
+  [/状態異常解除（自分）/g, "Status cleared (self)"],
+  [/状態異常解除/g, "Status cleared"],
+  // ── 戦闘ログ専用フレーズ
   [/休憩で HP\+(\d+)/g, "Rested for HP +$1"],
   [/購入:?\s*/g, "Purchased: "],
-  [/シールド\s*(\d+)/g, "Shield $1"],
+  [/シールド\s*\+?(\d+)/g, "Shield +$1"],
   [/ガード\s*\+(\d+)/g, "Guard +$1"],
   [/ドロー\s*(\d+)/g, "Draw $1"],
   [/カードを\s*(\d+)\s*枚引く/g, "draw $1"],
+  [/捨て札をシャッフルして山に/g, "Reshuffled discard into deck"],
+  [/クリティカル（PHY）/g, "Critical (PHY)"],
+  [/クリティカル（INT）/g, "Critical (INT)"],
+  [/敵クリティカル（PHY）/g, "Enemy critical (PHY)"],
+  [/敵クリティカル（INT）/g, "Enemy critical (INT)"],
+  [/不屈：?このターン被ダメ半減/g, "Steadfast: half DMG taken this turn"],
+  [/不屈:?\s*ダメージ半減/g, "Steadfast: DMG halved"],
+  [/不屈:?\s*ダメ半減/g, "Steadfast: DMG halved"],
+  [/特殊ダメージ（最大HP\s*(\d+)%）→ HP-(\d+)/g, "Special DMG (max HP $1%) → HP -$2"],
+  [/PHY全体攻撃\s*(\d+)%\s*→\s*合計ダメ\s*(\d+)/g, "PHY area $1% → total $2 DMG"],
+  [/INT全体攻撃\s*(\d+)%\s*→\s*合計ダメ\s*(\d+)/g, "INT area $1% → total $2 DMG"],
+  [/敵\s*PHY\s*(\d+)%\s*→\s*被ダメージ\s*(\d+)/g, "Enemy PHY $1% → DMG taken $2"],
+  [/敵\s*INT\s*(\d+)%\s*→\s*被ダメージ\s*(\d+)/g, "Enemy INT $1% → DMG taken $2"],
+  [/敵\s*PHY\s*(-?\d+)/g, "Enemy PHY $1"],
+  [/敵\s*INT\s*(-?\d+)/g, "Enemy INT $1"],
+  [/リカバリー:\s*係数(.+)/g, "Recovery: coef $1"],
+  [/HP\+(\d+)（自己回復）/g, "HP +$1 (self heal)"],
+  [/HP\+(\d+)/g, "HP +$1"],
+  [/HP-(\d+)/g, "HP -$1"],
+  [/(\S+)\s*行動:\s*guard/g, "$1 action: guard"],
+  [/(\S+)\s*行動:\s*buffSelf/g, "$1 action: self buff"],
+  [/(\S+)\s*行動:\s*healSelf/g, "$1 action: self heal"],
+  [/(\S+)\s*行動:\s*([a-zA-Z]+)/g, "$1 action: $2"],
+  [/致死ダメージを耐えた！HP\s*1\s*で生存！/g, "Survived a lethal hit at HP 1!"],
+  [/致死ダメ.*$/g, "Survived a lethal hit at HP 1!"],
+  [/付与/g, "applied"],
   [/(\d+)\s*ダメ\b/g, "$1 DMG"],
+  [/ダメージ/g, "DMG"],
+  [/ダメ/g, "DMG"],
   [/(\d+)\s*回復/g, "+$1 HP"],
-  [/(\d+)\s*HP/g, "$1 HP"],
+  // 休憩 / 自己回復 / 強化 のラベル
+  [/自己回復/g, "self heal"],
+  [/強化/g, "buff"],
+  [/防御/g, "guard"],
+  [/敵全体/g, "all enemies"],
+  [/敵/g, "enemy"],
+  [/（/g, " ("],
+  [/）/g, ")"],
 ];
 
 /**

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -24,6 +24,10 @@ import {
   translateCombatLog,
   translateGameText,
   registerNameMapping,
+  getEnHeroName,
+  getEnEnemyName,
+  getEnExtName,
+  getEnExtSkill,
 } from "./i18n.js";
 import {
   img,
@@ -1654,10 +1658,18 @@ function syncResources() {
     } else {
       const cur = mapNodeById(runState.lastMapNodeId);
       if (cur) {
+        // cur.label は maps.js が JA リテラルでベイク (エネミー / 休憩 / etc)。
+        // ノード type から i18n 化したラベルを引く。
+        const labelTr =
+          cur.type === "fight" ? (cur.elite ? ti18n("node.elite") : ti18n("node.battle")) :
+          cur.type === "rest"  ? ti18n("node.rest") :
+          cur.type === "shop"  ? ti18n("node.shop") :
+          cur.type === "craft" ? ti18n("node.craft") :
+          cur.type === "boss"  ? ti18n("node.boss") : (cur.label || "");
         const tmpl = ti18n("layer.cur");
         layerEl.textContent = tmpl
           .replace("{n}", cur.layer + 1)
-          .replace("{label}", cur.label);
+          .replace("{label}", labelTr);
       } else {
         layerEl.textContent = "—";
       }
@@ -2417,16 +2429,10 @@ function simplifyEffectText(text) {
   return t;
 }
 
-const PEEK_HELP_SNIPPETS = {
-  guard:  "<strong>ガード</strong> — ターン中、PHY/INT ダメージを数値分だけ先に吸収（味方はターン開始で 0）。",
-  shield: "<strong>シールド</strong> — 特殊ダメージ（最大 HP 割合など）のみ吸収。PHY/INT 通常攻撃には無効。",
-  energy: "<strong>⚡ エナジー</strong> — ターンで使える行動コスト。次ターン開始時に最大まで回復。",
-  draw:   "<strong>ドロー</strong> — 山札から手札へカードを引く。山が空なら捨て札をシャッフルして山にする。",
-  phy:    "<strong>PHY</strong> — 物理攻撃の基礎値。PHY 依存スキルのダメージに使う。",
-  int:    "<strong>INT</strong> — 知略の基礎値。INT 攻撃や回復係数に関わる。",
-  agi:    "<strong>AGI</strong> — このプロトでは主にクリティカル率に反映。",
-  hp:     "<strong>HP</strong> — 0 で敗北。回復は最大値を超えない。",
-};
+// 旧: ハードコード JA。今は ti18n("peek.<k>") から取得 (JA / EN 両対応)。
+function peekHelpSnippet(key) {
+  return ti18n("peek." + key, "");
+}
 
 // ─── ターゲット表示バッジ (#44 SPEC-005 Phase 1) ──────────────────
 /**
@@ -2474,7 +2480,7 @@ function buildTargetBadgeHtml(card) {
 
 function buildPeekHelpHtml(keys) {
   if (!keys || !keys.length) return "";
-  const parts = keys.map((k) => PEEK_HELP_SNIPPETS[k]).filter(Boolean);
+  const parts = keys.map((k) => peekHelpSnippet(k)).filter(Boolean);
   if (!parts.length) return "";
   return (
     '<div class="card-peek-help">' +
@@ -2863,6 +2869,18 @@ function renderCombat() {
     // SPEC-006 Phase 4b: コスト + キャスター不在の両方をチェック
     const playable = canPlayCard(card, combat);
     const reasonBadge = !playable ? unplayableBadge(card, combat) : null;
+    // i18n: caster.js が返す JA バッジを EN 表示用に翻訳
+    if (reasonBadge) {
+      if (reasonBadge.badge === "⚡不足") {
+        reasonBadge.badge = ti18n("badge.energyShort", "⚡不足");
+        reasonBadge.title = ti18n("badge.energyTip").replace("{need}", card.cost).replace("{have}", combat.energy ?? 0);
+      } else if (reasonBadge.badge === "👤不在") {
+        const role = card?.caster ?? "foremost";
+        const roleLabel = tCasterLabel(role, CASTER_ROLE_LABELS[role] || role);
+        reasonBadge.badge = ti18n("badge.casterShort", "👤不在");
+        reasonBadge.title = ti18n("badge.casterTip").replace("{role}", roleLabel);
+      }
+    }
     slot.className = "card-slot" + (!playable ? " card-slot--disabled" : "");
     slot.setAttribute("data-cost", String(card.cost));
     slot.setAttribute("data-rarity", rarity);
@@ -7938,22 +7956,22 @@ function openCraftScreen() {
 
   el.innerHTML = `
     <div class="craft-header">
-      <h2>クラフト</h2>
-      <p class="craft-sub">エクステンションを獲得するか、デッキを強化しましょう</p>
+      <h2>${escapeHtml(ti18n("craft.title"))}</h2>
+      <p class="craft-sub">${escapeHtml(ti18n("craft.sub"))}</p>
     </div>
     <div class="craft-choices">
       <div class="craft-option" id="craftOptGet">
-        <div class="craft-opt-title">エクステ獲得</div>
-        <div class="craft-opt-desc">累積カードプールからカードを3枚提示します。1枚をデッキに追加できます。</div>
-        <button class="action craft-opt-btn" id="btnCraftGet">獲得する</button>
+        <div class="craft-opt-title">${escapeHtml(ti18n("craft.get.title"))}</div>
+        <div class="craft-opt-desc">${escapeHtml(ti18n("craft.get.desc"))}</div>
+        <button class="action craft-opt-btn" id="btnCraftGet">${escapeHtml(ti18n("craft.get.button"))}</button>
       </div>
       <div class="craft-option" id="craftOptUpgrade">
-        <div class="craft-opt-title">打ち直し</div>
-        <div class="craft-opt-desc">デッキ内のノービスカードを1枚選んでエリートにランクアップします。</div>
-        <button class="action craft-opt-btn" id="btnCraftUpgrade">打ち直す</button>
+        <div class="craft-opt-title">${escapeHtml(ti18n("craft.reroll.title"))}</div>
+        <div class="craft-opt-desc">${escapeHtml(ti18n("craft.reroll.desc"))}</div>
+        <button class="action craft-opt-btn" id="btnCraftUpgrade">${escapeHtml(ti18n("craft.reroll.button"))}</button>
       </div>
     </div>
-    <button class="craft-leave-btn" id="btnLeaveCraft">← マップに戻る</button>
+    <button class="craft-leave-btn" id="btnLeaveCraft">${escapeHtml(ti18n("craft.backMap"))}</button>
   `;
 
   document.getElementById("btnCraftGet").addEventListener("click", () => {
@@ -7992,7 +8010,7 @@ function openCraftGetCard() {
     playerGuard: 0, playerShield: 0, energyMax: 3, energy: 3,
   };
 
-  el.innerHTML = `<div class="craft-header"><h2>エクステ獲得</h2><p class="craft-sub">1枚を選んでデッキに追加します</p></div>`;
+  el.innerHTML = `<div class="craft-header"><h2>${escapeHtml(ti18n("craft.get.title"))}</h2><p class="craft-sub">${escapeHtml(ti18n("craft.get.pick"))}</p></div>`;
   const list = document.createElement("div");
   list.className = "craft-reward-list";
   offerKeys.forEach(key => {
@@ -8001,7 +8019,7 @@ function openCraftGetCard() {
     const btn = buildRewardPickButton(def, mockS);
     btn.addEventListener("click", () => {
       runState.deck.push(copyCard(key));
-      clog(`クラフト獲得: ${def.extNameJa}`);
+      clog(ti18n("clog.craftGet").replace("{name}", tExt(def.extId, def.extNameJa)));
       leaveCraft();
     });
     list.appendChild(btn);
@@ -8010,7 +8028,7 @@ function openCraftGetCard() {
 
   const skipBtn = document.createElement("button");
   skipBtn.className = "craft-leave-btn";
-  skipBtn.textContent = "スキップ";
+  skipBtn.textContent = ti18n("craft.skip");
   skipBtn.addEventListener("click", leaveCraft);
   el.appendChild(skipBtn);
 }
@@ -8027,15 +8045,15 @@ function openCraftUpgrade() {
 
   if (upgradeable.length === 0) {
     el.innerHTML = `
-      <div class="craft-header"><h2>打ち直し</h2></div>
-      <p style="text-align:center;color:var(--muted);margin:2rem 0;">アップグレード可能なノービスカードがありません</p>
-      <button class="craft-leave-btn" id="btnLeaveCraft2">← 戻る</button>
+      <div class="craft-header"><h2>${escapeHtml(ti18n("craft.reroll.title"))}</h2></div>
+      <p style="text-align:center;color:var(--muted);margin:2rem 0;">${escapeHtml(ti18n("craft.reroll.empty"))}</p>
+      <button class="craft-leave-btn" id="btnLeaveCraft2">${escapeHtml(ti18n("craft.back"))}</button>
     `;
     document.getElementById("btnLeaveCraft2").addEventListener("click", () => openCraftScreen());
     return;
   }
 
-  el.innerHTML = `<div class="craft-header"><h2>打ち直し</h2><p class="craft-sub">ランクアップするカードを選んでください（ノービス → エリート）</p></div>`;
+  el.innerHTML = `<div class="craft-header"><h2>${escapeHtml(ti18n("craft.reroll.title"))}</h2><p class="craft-sub">${escapeHtml(ti18n("craft.reroll.pick"))}</p></div>`;
   const list = document.createElement("div");
   list.className = "craft-upgrade-list";
 
@@ -8066,14 +8084,17 @@ function openCraftUpgrade() {
 
     const selBtn = document.createElement("button");
     selBtn.className = "action craft-opt-btn";
-    selBtn.textContent = "このカードを強化";
+    selBtn.textContent = ti18n("craft.upgrade.button");
     selBtn.addEventListener("click", () => {
       // β1: 元カードのコストを保持してランクアップ
       const originalCost = runState.deck[idx].cost;
       const upgraded = copyCard(upgradeKey);
       upgraded.cost = originalCost;
       runState.deck[idx] = upgraded;
-      clog(`打ち直し: ${card.extNameJa} → ${upgradeDef.extNameJa} (コスト ${originalCost} 据え置き)`);
+      clog(ti18n("clog.craftUpgrade")
+        .replace("{from}", tExt(card.extId, card.extNameJa))
+        .replace("{to}", tExt(upgradeDef.extId, upgradeDef.extNameJa))
+        .replace("{cost}", originalCost));
       leaveCraft();
     });
 
@@ -8088,7 +8109,7 @@ function openCraftUpgrade() {
 
   const backBtn = document.createElement("button");
   backBtn.className = "craft-leave-btn";
-  backBtn.textContent = "← 戻る";
+  backBtn.textContent = ti18n("craft.back");
   backBtn.addEventListener("click", () => openCraftScreen());
   el.appendChild(backBtn);
 }
@@ -8140,13 +8161,19 @@ function closeDeckModal() {
 }
 
 // ─── 初期化 ───────────────────────────────────────────────────────
-// タイトル画面の言語トグルで、現在の言語に対応するボタンに active クラスを付与
+// タイトル画面の言語トグルで、現在の言語に対応するボタンに active クラスを付与。
+// 加えてヘッダー常設ボタンのラベルを「次に切り替わる言語」に更新 (現在 JA → 次は EN を表示する慣例)。
 function syncLangToggleActive() {
   const cur = getLang();
   document.querySelectorAll("#langToggle .lang-btn").forEach(btn => {
     const isActive = btn.getAttribute("data-lang") === cur;
     btn.classList.toggle("lang-btn--active", isActive);
     btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+  });
+  // ヘッダー常設ボタンには現在の言語コードを表示 (タップで他方に切り替わる)
+  document.querySelectorAll(".btn-lang-hd").forEach(btn => {
+    btn.textContent = cur === "en" ? "EN" : "JP";
+    btn.setAttribute("aria-pressed", "false");
   });
 }
 
@@ -8169,21 +8196,33 @@ async function init() {
     // i18n: 戦闘ログの post-process 用に JA→EN 名マッピングを登録
     // (cards.js の clog はカードや caster 名を JA で埋め込むため、
     //  EN モードでは clog 通過時にここで登録した名前を一括置換する)
+    // lang 状態に依存しないルックアップを使うので、JA で開始 → 後から EN に
+    // 切り替えた場合でも既に置換マップが構築されている。
     for (const h of HERO_ROSTER) {
-      const en = tHero(h.heroId, h.nameJa);
+      const en = getEnHeroName(h.heroId);
       if (en && en !== h.nameJa) registerNameMapping(h.nameJa, en);
     }
     for (const id of Object.keys(ENEMY_DEFS)) {
       const def = ENEMY_DEFS[id];
       if (!def) continue;
-      const en = tEnemy(def.imgId, def.name);
+      const en = getEnEnemyName(def.imgId);
       if (en && en !== def.name) registerNameMapping(def.name, en);
     }
     for (const id of Object.keys(BOSS_DEFS)) {
       const def = BOSS_DEFS[id];
       if (!def) continue;
-      const en = tEnemy(def.imgId, def.name);
+      const en = getEnEnemyName(def.imgId);
       if (en && en !== def.name) registerNameMapping(def.name, en);
+    }
+    // 全エクステ名 (cards.js play() 内 clog がカード名を JA で埋め込む対策)
+    // CARD_LIBRARY 全件の extNameJa / skillNameJa を JA→EN マップに登録。
+    for (const key of Object.keys(CARD_LIBRARY)) {
+      const def = CARD_LIBRARY[key];
+      if (!def) continue;
+      const enName = getEnExtName(def.extId);
+      if (enName && enName !== def.extNameJa) registerNameMapping(def.extNameJa, enName);
+      const enSkill = getEnExtSkill(def.extId);
+      if (enSkill && def.skillNameJa && enSkill !== def.skillNameJa) registerNameMapping(def.skillNameJa, enSkill);
     }
   } catch (e) {
     console.error("[init] data load failed", e);
@@ -8282,6 +8321,16 @@ async function init() {
       setLang(btn.getAttribute("data-lang"));
     });
   }
+  // ── ヘッダー常設の言語トグル (map / combat) ──
+  // 1 タップで JA ⇄ EN を切り替える。プレイ中の任意のタイミングで使えるよう設置。
+  ["btnLangToggleMap", "btnLangToggleCombat"].forEach(id => {
+    const b = document.getElementById(id);
+    if (!b) return;
+    b.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      setLang(getLang() === "en" ? "ja" : "en");
+    });
+  });
   // 言語変更時に再描画が必要な箇所 (combat / map / shop / hero名など)
   onLangChange(() => {
     syncLangToggleActive();


### PR DESCRIPTION
PR #110 が round 5 の push 前にマージされてしまっていたので、main から再ブランチして cherry-pick したものです。内容は #110 で予定していた最後のラウンド分と同等。

## ヘッダー常設の言語トグル
- マップ / バトルヘッダーの右側 (ヘルプ「?」の隣) に \`<button class=\"btn-lang-hd\">\` を追加
- 現在の言語コード ("JP" / "EN") を表示、タップで他方に切替
- \`setLang()\` 経由で全画面再描画されるので即時反映
- プレイ中の任意のタイミングで JA ⇄ EN 切替が可能

## クラフト画面
- "クラフト / エクステ獲得 / 打ち直し / 獲得する / 打ち直す / 累積カードプール… / アップグレード可能なノービス… / ← マップに戻る / ← 戻る / スキップ / このカードを強化" すべて i18n 化
- "クラフト獲得: …" / "打ち直し: A → B (コスト N 据え置き)" の clog をテンプレ化

## カード Peek / プレビュー ツールチップ
- \`PEEK_HELP_SNIPPETS\` (8 種: guard / shield / energy / draw / PHY / INT / AGI / HP) のハードコード JA を撤去
- \`peekHelpSnippet(key) → ti18n(\"peek.\" + key)\` に変更し、ui.json に EN 8 件追加

## プレイ不能バッジ ("⚡不足" / "👤不在")
- \`unplayableBadge()\` は caster.js (共有モジュール) で JA 固定値を返すので、render code 側でポストトランスレート
- ui.json に \`badge.energyShort\` / \`.energyTip\` / \`.casterShort\` / \`.casterTip\` を追加

## 戦闘ログ全面強化
- **CARD_LIBRARY 全件** のエクステ名・スキル名を JA→EN マップに登録 → cards.js play() 内 clog の "【織田信長】が【ノービスアーマー】を使用" が "[Nobunaga Oda] used [Novice Armor]" に
- 名前マップ登録は \`getEnHeroName/EnemyName/ExtName/ExtSkill\` の **言語非依存ルックアップ** に変更 → JA で起動 → 後から EN 切替でも置換が効く
- 約 30 種のパターン追加: 「敵 PHY N% → 被ダメージ M」「PHY全体攻撃 / INT全体攻撃」「クリティカル(PHY/INT) / 敵クリティカル」「不屈 / 状態異常解除 / 捨て札をシャッフルして山に / シールド / ガード / ドロー / リカバリー / 特殊ダメージ / 致死ダメージ / 自己回復 / 強化 / 防御 / 行動: kind」 等

## マップ Layer ピル
"L1 · エネミー" → "L1 · Enemy"。\`maps.js\` がベイクする JA リテラル \`cur.label\` を type ベースで再翻訳。

## ショップカード "ダメ" 表示バグ
旧 \`[/ダメ\b/g, \"DMG\"]\` は JS の \`\b\` が日本語に発火しないため漏れていた。
- ダメージ → DMG (longer first)
- PHYダメ / INTダメ → PHY DMG / INT DMG
- ダメ → DMG (catch-all, no \b)
ショップ券面 "All 25-30% ダメ" → "All 25-30% DMG" 正常表示

## Test plan
- [ ] マップ・バトルヘッダー右上に "JP" / "EN" ボタンが出る
- [ ] タップで言語切替、ボタン文字が "JP" ⇄ "EN" に
- [ ] クラフト画面の各テキスト・ボタンが EN
- [ ] 手札カードの長押し / ホバーで peek ツールチップ EN 表示
- [ ] エナジー不足カードに "⚡ low" バッジ
- [ ] 戦闘ログ "Battle start vs Creeper-venti" / "[Nobunaga Oda] used [Novice Armor]" / "Enemy PHY 90% → DMG taken 8" が EN
- [ ] マップヘッダー Layer ピル "L1 · Enemy"
- [ ] ショップ券面 effect 行 "All 25-30% DMG"