### PR TITLE
feat(balance): boss-only Vigilance backlash for same-card chain abuse

### DIFF
--- a/prototype/data/i18n/ui.json
+++ b/prototype/data/i18n/ui.json
@@ -28,6 +28,8 @@
   "combat.tag.boss":           { "ja": "（ボス）", "en": " (Boss)" },
   "combat.tag.elite":          { "ja": "（精鋭）", "en": " (Elite)" },
   "combat.boss.shield":        { "ja": "ボスはシールド {n} を持ちます！", "en": "Boss starts with Shield {n}!" },
+  "combat.boss.vigilance.intro": { "ja": "ボスの警戒: 同種カードを 1 ターン中に 3 回以上使うと、3 回目以降は反動ダメージ", "en": "Boss vigilance: using the same card 3+ times in one turn deals self-damage from the 3rd play onward" },
+  "combat.boss.vigilance.hit":  { "ja": "警戒の反動: 「{name}」{count} 枚目 → HP -{n}", "en": "Vigilance backlash: \"{name}\" #{count} → HP -{n}" },
   "clog.enterChapter":         { "ja": "── 章 {id}「{name}」へ ──", "en": "── Entering Ch.{id}: {name} ──" },
   "combat.deck.aria":          { "ja": "残りデッキを表示", "en": "Show remaining deck" },
   "combat.exhaust.title":      { "ja": "消耗済みカード", "en": "Exhausted cards" },

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -665,6 +665,11 @@ function clog(msg) {
 function sleep(ms) { return new Promise(res => setTimeout(res, ms)); }
 const ENEMY_ACTION_GAP_MS = 850;
 
+/** ボス警戒 (Vigilance) — 同 libraryKey カードを 1 ターン中に N 回以上使うと
+ *  N 回目以降に反動ダメージ。1-2 回は無料、3 回目から (count - 2) * BASE のリニア。
+ *  3rd: 4 / 4th: 8 / 5th: 12 / 6th: 16 / 7th: 20 dmg。Boss 戦のみ作動。 */
+const VIGILANCE_BACKLASH_BASE_DMG = 4;
+
 /** SPEC-005 Phase 3h: data-pos スロット内の combatant-portrait-wrap を解決
  *  - heroes[0] / enemies[0] (前衛) → 静的 ID (#playerPortraitWrap / #enemyPortraitWrap)
  *  - heroes[1+] / enemies[1+] → .party-slot[data-pos="N"] .combatant-portrait-wrap
@@ -2049,6 +2054,10 @@ function startCombatFromMapNode(node) {
     isBoss,
     bossPhase,
     bossDef: isBoss ? bossDef : null,
+    // ボス戦のみ「警戒 (Vigilance)」: 同種カード (libraryKey) を 1 ターン中に
+    // 3 回以上使うと 3 回目以降は反動ダメージを受ける chain-abuse 抑止機構。
+    bossVigilance: isBoss,
+    cardPlayCounts: {}, // libraryKey -> 今ターンの使用回数
     enemyName: enemyDef.name,
     enemyImgId: enemyDef.imgId,
     enemyDefId: enemyDef.id,
@@ -2148,6 +2157,10 @@ function startCombatFromMapNode(node) {
   clog(ti18n("combat.start").replace("{name}", enemyDispLogName) + battleSuffix);
   if (isBoss && (enemyDef.initialShield || 0) > 0) {
     clog(ti18n("combat.boss.shield").replace("{n}", enemyDef.initialShield));
+  }
+  // ボス戦のみ警戒 (Vigilance) を開幕通知
+  if (isBoss) {
+    clog(ti18n("combat.boss.vigilance.intro"));
   }
   applyHeroPassiveOnCombatStart(combat);
   syncLlExtSlots();
@@ -2269,6 +2282,8 @@ function startPlayerTurn() {
   }
   combat.playerGuard = 0;  // legacy mirror (heroes[0])
   combat.damageReducedThisTurn = false;
+  // ボス警戒 (Vigilance) の同種カード使用回数をターン毎にリセット
+  combat.cardPlayCounts = {};
 
   // SPEC-006 Phase 4f + β1 修正: 毒 / 出血 ティックを per-hero (生存ヒーロー個別)
   // 旧: 毒のみ tick、出血は PHY 攻撃時のボーナスのみ → 出血ダメージが入らないと報告
@@ -5683,6 +5698,40 @@ async function playCard(idx) {
     clog(`【消耗】${card.extNameJa} を除外`);
   } else {
     combat.discardPile.push(card);
+  }
+  // ボス警戒 (Vigilance) 反動: 同 libraryKey のカードを 1 ターン中に
+  // 3 回以上使うと、3 回目以降は使用ごとに反動ダメージが入る。
+  // 1-2 回までは無料、3 回目から線形に増加 (3rd: +1, 4th: +2, ...) × VIGILANCE_BASE
+  if (combat.bossVigilance && card.libraryKey) {
+    const counts = combat.cardPlayCounts || (combat.cardPlayCounts = {});
+    const k = card.libraryKey;
+    counts[k] = (counts[k] || 0) + 1;
+    const VIGILANCE_BASE = VIGILANCE_BACKLASH_BASE_DMG;
+    const VIGILANCE_FREE_THRESHOLD = 2;
+    if (counts[k] > VIGILANCE_FREE_THRESHOLD) {
+      const overage = counts[k] - VIGILANCE_FREE_THRESHOLD;
+      const dmg = overage * VIGILANCE_BASE;
+      const front = combat.heroes?.[0];
+      if (front) {
+        applyHpDeltaToHero(combat, front, -dmg);
+        flashPortrait("player", front);
+        playPortraitEffect("player", "debuff", front);
+      } else {
+        // legacy フォールバック
+        combat.playerHp = Math.max(0, (combat.playerHp || 0) - dmg);
+      }
+      const cardLabel = tExt(card.extId, card.extNameJa);
+      clog(ti18n("combat.boss.vigilance.hit")
+        .replace("{name}", cardLabel)
+        .replace("{count}", counts[k])
+        .replace("{n}", dmg));
+      checkResurrection(combat);
+      if (isPartyWipedOut(combat)) {
+        renderCombat();
+        endCombatLoss();
+        return;
+      }
+    }
   }
   card.play(combat, { caster, effectsResolved });
   // SPEC-006 Phase 4d: card.play() で変化した legacy stats を caster に書き戻す


### PR DESCRIPTION
## What
ボス戦のみ「警戒 (Vigilance)」を開幕に付与し、**同種カード (libraryKey 一致)** を 1 ターン中に 3 回以上使うと 3 回目以降は反動ダメージを受ける chain-abuse 抑止機構を追加。

| 同種使用回数 | 反動ダメ | 累計 |
|---|---|---|
| 1, 2 | 0 | 0 |
| 3 | 4 | 4 |
| 4 | 8 | 12 |
| 5 | 12 | 24 |
| 6 | 16 | 40 |
| 7 | 20 | 60 |

数式: \`(count - 2) × VIGILANCE_BACKLASH_BASE_DMG\` (BASE = 4 / [main.js](prototype/js/main.js) の定数で調整可)

## Why
コスト 0 ドロー + 攻撃のみにデッキを絞り込み、エナジーを消費せず無限に攻撃 → ノーダメ 1 ターン勝利という exploit に対する対策。

このルールは **狙い撃ち** 設計:
- 1-2 回までは無料 → 通常ビルドはほぼ無傷
- 3 回目以降の compounding penalty → 同種カード spam だけが失速
- mid-build (異なる攻撃 3 種 + ドロー 1 枚等) は問題なし
- ドロー archetype 自体は弱体化しない

ボス限定スコープにより、通常戦闘・エリート戦の自由度は維持。序盤の build 実験性を損なわない。

## 実装
- combat init: \`bossVigilance: isBoss\` / \`cardPlayCounts: {}\`
- \`startPlayerTurn()\`: 毎ターン \`cardPlayCounts\` を空にリセット
- 戦闘開始時の clog: ボス戦で警戒ルール通知
- \`playCard()\`: libraryKey 別にカウント、超過時に反動ダメ + portrait flash + debuff fx + clog。リザレクション / 全滅判定も通る

## i18n
- \`combat.boss.vigilance.intro\` (戦闘開始時の案内 / JA + EN)
- \`combat.boss.vigilance.hit\` (反動発生時の clog / JA + EN)

## Test plan
- [ ] ボス戦開幕に「ボスの警戒: …」のログが流れる
- [ ] 同じカードを 1 ターン中 2 回までは反動なし
- [ ] 3 回目で HP -4、4 回目で HP -8、5 回目で HP -12 が累積で入る
- [ ] **異なる**カードを連打した場合は反動なし
- [ ] 通常戦闘・エリート戦では Vigilance ログ・反動ダメージとも発生しない
- [ ] ターン終了 → 次ターン頭でカウンターがリセット (3 回目以降の反動が再び 1 から)
- [ ] 反動ダメで HP 0 → 敗北画面が正常に呼ばれる

## 調整ノブ
- 痛みが強すぎる: \`VIGILANCE_BACKLASH_BASE_DMG\` を 4 → 3 や 2 に
- 痛みが弱すぎる: 4 → 5 や 6 に
- 閾値変更: \`VIGILANCE_FREE_THRESHOLD\` (現在 2) を 1 にすれば 2 回目から痛む