### PR TITLE
fix(ux): render board + draw hand BEFORE combat-start passives fire

### DIFF
--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -2149,16 +2149,27 @@ function startCombatFromMapNode(node) {
   if (isBoss && (enemyDef.initialShield || 0) > 0) {
     clog(ti18n("combat.boss.shield").replace("{n}", enemyDef.initialShield));
   }
-  applyHeroPassiveOnCombatStart(combat);
+  // β1 UX: パッシブ発動前に「敵 + 手札 + intent」を最新化する。
+  // 旧版は applyHeroPassiveOnCombatStart → applyPassiveTriggerAsync → startPlayerTurn
+  // の順で、startPlayerTurn が手札をドローするまで「ファラオの呪い」等のカットインが
+  // 空の手札 + 古い表示の上に重なって状況がわかりにくかった。
+  // → 先に initial draw + intent advance + render を済ませてから passives を発動する。
   syncLlExtSlots();
-  // SPEC-006 §18.6: PassiveDef DSL の combat.started trigger を発動
-  // 各ヒーローのカットインを「前衛 → 中衛 → 後衛」の順に sequential 表示するため
-  // async 版を fire-and-forget で起動し、終わってから startPlayerTurn を呼ぶ。
-  // カットイン中は combatInputLocked = true にして手札クリック等を無効化。
+  combat.energy = combat.energyMax + (combat.bonusEnergyNext || 0);
+  combat.bonusEnergyNext = 0;
+  drawCards(combat, 5);
+  advanceEnemyIntent();
+  renderCombat();
+
+  // 手札と敵が画面に出てから passives を順次発動。
   combatInputLocked = true;
+  applyHeroPassiveOnCombatStart(combat);
+  // SPEC-006 §18.6: PassiveDef DSL の combat.started trigger を順次発動
+  // (前衛 → 中衛 → 後衛 のカットイン順に sequential 表示)。
+  // 完了後はカットインで変化したステを反映するため renderCombat を再実行。
   applyPassiveTriggerAsync(combat, "combat.started").finally(() => {
     combatInputLocked = false;
-    startPlayerTurn();
+    renderCombat();
   });
 }
 


### PR DESCRIPTION
## 問題
戦闘開始時に発動するパッシブスキル (例: ツタンカーメンの「ファラオの呪い」) のカットインが、まだ手札 + 敵 + intent が描画されていないタイミングで発動して何が起きているか分かりにくかった。

## 修正
\`startCombatFromMapNode\` の順序を入れ替え:

**Before:**
1. clog \"戦闘開始 vs ...\"
2. \`applyHeroPassiveOnCombatStart\` (sync passive 発動 — カットイン重なる)
3. \`applyPassiveTriggerAsync(\"combat.started\")\` (DSL passive 発動)
4. \`.finally\`: \`startPlayerTurn()\` (= ここで初めて手札 5 枚ドロー + intent 進行 + render)

**After:**
1. clog \"戦闘開始 vs ...\"
2. **(新)** \`drawCards(5)\` + \`advanceEnemyIntent()\` + \`renderCombat()\`
3. \`combatInputLocked = true\`
4. \`applyHeroPassiveOnCombatStart\` (passive 発動 — 既に盤面が完成した上にカットイン)
5. \`applyPassiveTriggerAsync(\"combat.started\")\` (DSL passive 発動)
6. \`.finally\`: \`combatInputLocked = false\` + \`renderCombat()\` (passive で変化したステを反映)

## 安全性
- 旧 \`.finally\` で呼んでいた \`startPlayerTurn()\` の他の処理 (毒/出血 tick / Guard リセット / PHY ペナルティリセット / Doyle HP トリガー判定) はすべてターン 1 では no-op だったため、削除しても影響なし。
- 既存パッシブで「戦闘開始時にカードドロー」をする登録がないため、先に 5 枚引いてから passive を発動しても挙動は変わらない。
- ターン 2 以降の \`enemyTurn() → startPlayerTurn()\` 経路は触っていないので変更なし。

## Verified in Launch preview
通常戦闘開始時: hand=5、energy=3/3、intent=「先頭: 5 ダメージ」、ログ「戦闘開始 vs エルククローナ ヴェンティ」 → すべて表示済みの状態でパッシブ発動。

## Test plan
- [ ] ツタンカーメン (or 他の戦闘開始時パッシブ持ちヒーロー) で出撃
- [ ] バトル開幕にカットイン (\"ファラオの呪い\" 等) が出る前に、手札 5 枚 + 敵 + intent が表示済みになっている
- [ ] カットイン後に passive で変化したステが反映される
- [ ] 通常の戦闘 (passive なし) でも手札 5 枚 + intent が即時表示される
- [ ] 敵ターン終了 → 自ターン頭の通常フローも壊れていない (毒/出血ティック等)