### PR TITLE
fix(i18n): card-focus overlays + damage-breakdown clog

### DIFF
--- a/prototype/js/i18n.js
+++ b/prototype/js/i18n.js
@@ -182,6 +182,16 @@ const RUNTIME_REPLACEMENTS = [
   [/INT最高/g, "Highest INT"],
   [/HP最高/g,  "Highest HP"],
   [/AGI最高/g, "Highest AGI"],
+  // 「敵INT -2」「敵PHY -1」: 既にカードのターゲット pill (Front 等) で陣営が
+  // 分かるので「敵」プレフィックスは省略して PHY/INT/AGI/HP のみ残す。
+  [/敵\s*INT\s*([+\-]?\d+)/g, "INT $1"],
+  [/敵\s*PHY\s*([+\-]?\d+)/g, "PHY $1"],
+  [/敵\s*AGI\s*([+\-]?\d+)/g, "AGI $1"],
+  [/敵\s*HP\s*([+\-]?\d+)/g, "HP $1"],
+  [/味方\s*INT\s*([+\-]?\d+)/g, "INT $1"],
+  [/味方\s*PHY\s*([+\-]?\d+)/g, "PHY $1"],
+  [/味方\s*AGI\s*([+\-]?\d+)/g, "AGI $1"],
+  [/味方\s*HP\s*([+\-]?\d+)/g, "HP $1"],
   // 「ダメージ」を先に置換 → 残った「ダメ」だけを後で潰す。
   // 旧版は `/ダメ\b/g` を使っていたが JS の \b は非 ASCII の境界に発火しないため
   // 「25-30% ダメ」が翻訳されないままだった (shop カード券面で再発)。
@@ -386,6 +396,11 @@ const COMBAT_LOG_REPLACEMENTS = [
   [/INT全体攻撃\s*(\d+)%\s*→\s*合計ダメ\s*(\d+)/g, "INT area $1% → total $2 DMG"],
   [/敵\s*PHY\s*(\d+)%\s*→\s*被ダメージ\s*(\d+)/g, "Enemy PHY $1% → DMG taken $2"],
   [/敵\s*INT\s*(\d+)%\s*→\s*被ダメージ\s*(\d+)/g, "Enemy INT $1% → DMG taken $2"],
+  // プレイヤーの単体攻撃 clog "PHY攻撃 50% → 基礎4 カット8% → HP-4" 等
+  [/PHY攻撃\s*(\d+)%\s*→\s*基礎(\d+)\s*カット(\d+)%/g, "PHY $1% → base $2 cut $3%"],
+  [/INT攻撃\s*(\d+)%\s*→\s*基礎(\d+)\s*カット(\d+)%/g, "INT $1% → base $2 cut $3%"],
+  [/\+脆弱(\d+)/g, "+Vuln $1"],
+  [/脆弱/g, "Vuln"],
   [/敵\s*PHY\s*(-?\d+)/g, "Enemy PHY $1"],
   [/敵\s*INT\s*(-?\d+)/g, "Enemy INT $1"],
   [/リカバリー:\s*係数(.+)/g, "Recovery: coef $1"],

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -2678,11 +2678,12 @@ function setCardPreview(card) {
         const amt = predictEffectHeal(effect, caster);
         if (amt > 0) { overlayText = `+${amt}`; overlayClass = "preview-overlay--heal"; }
       } else if (kind === "status") {
-        // 「毒 ×2」のような文字をそのまま簡略表示
-        overlayText = String(effect.text).replace(/\s+/g, "");
+        // 「毒 ×2」のような文字を i18n 経由で簡略表示 (translateGameText で
+        // 「毒」→「Poison」「ガード+N」→「Guard +N」等に変換される)
+        overlayText = translateGameText(String(effect.text)).replace(/\s+/g, "");
         overlayClass = "preview-overlay--status";
       } else if (kind === "buff") {
-        overlayText = String(effect.text).replace(/\s+/g, "");
+        overlayText = translateGameText(String(effect.text)).replace(/\s+/g, "");
         overlayClass = "preview-overlay--buff";
       }
       if (overlayText) {


### PR DESCRIPTION
EN モード playtest で残っていた 2 種の JA リーク修正。

## 1. カードフォーカス時のフローティング表示 (\"ガード+7\" / \"敵INT-2\")
カードを focus すると \`setCardPreview()\` が effects[] を対象 portrait にオーバーレイする。\`kind=\"status\"\` / \`kind=\"buff\"\` の枝で \`effect.text\` をそのまま使っていたため、JA リテラル (\"ガード +7\" / \"敵INT -2\") が EN モードでも残留。

修正: オーバーレイテキストを \`translateGameText()\` 経由に変更。

| 元 | 翻訳後 |
|---|---|
| ガード +7 | Guard+7 |
| 敵INT -2 | INT-2 |

「敵」プレフィックスは意図的にドロップ — カード上のターゲット pill (Front/All 等) が既に陣営を示しているため。短い overlay box に収まる長さに調整。

\`translateGameText\` 新規パターン追加:
- 敵 INT/PHY/AGI/HP ±N → bare \"INT/PHY/AGI/HP ±N\"
- 味方 INT/PHY/AGI/HP ±N → 同上

## 2. ダメージ内訳 clog (\"PHY攻撃 N% → 基礎X カットY% → HP-Z\")
単体攻撃 helper (\`dealPhySkillToEnemy\` / \`dealIntSkillToEnemy\`) が出力する内訳ログ。前半 \"PHY攻撃\" は翻訳済みだったが、\"基礎N カットM%\" 部分がパターン未対応だった。

\`translateCombatLog\` 新規パターン:
- \`PHY攻撃 N% → 基礎X カットY%\` → \`PHY N% → base X cut Y%\`
- \`INT攻撃 N% → 基礎X カットY%\` → \`INT N% → base X cut Y%\`
- \`+脆弱N\` → \`+Vuln N\`, 単独 \`脆弱\` → \`Vuln\`

既存の \`HP-N\` → \`HP -N\` ルールと組み合わせて全文:
- 元: \`PHY攻撃 57% → 基礎4 カット4% → HP-4\`
- EN: \`PHY 57% → base 4 cut 4% → HP -4\`

## Verified in Launch preview
- Novice Armor focus → overlays \"PHY+2\" / \"Guard+7\"
- Novice Musket focus → overlays \"-2\" (dmg pred) / \"INT-2\"
- Novice Blade play → clog \"PHY 57% → base 4 cut 4% → HP -4\"