### PR TITLE
release(v1.2.0): per-version ranking filter + version bump

### DIFF
--- a/prototype/data/i18n/ui.json
+++ b/prototype/data/i18n/ui.json
@@ -92,6 +92,9 @@
   "reward.intro":              { "ja": "バトル勝利おめでとうございます。追加するカードを 1 枚選ぶか、スキップしてマップへ戻ります。", "en": "Congratulations on the victory! Choose one card to add, or skip to return to the map." },
   "reward.skipFull":           { "ja": "スキップ（報酬なし）", "en": "Skip (no reward)" },
   "ranking.regulation":        { "ja": "レギュレーション", "en": "Regulation" },
+  "ranking.version":           { "ja": "バージョン", "en": "Version" },
+  "ranking.version.all":       { "ja": "全バージョン", "en": "All versions" },
+  "ranking.version.legacy":    { "ja": "旧版 (バージョン未設定)", "en": "Legacy (no version)" },
   "ranking.score":             { "ja": "スコア", "en": "Score" },
   "ranking.rank":              { "ja": "順位", "en": "Rank" },
   "ranking.player":            { "ja": "プレイヤー", "en": "Player" },
@@ -187,7 +190,7 @@
   "rarity.legendary":          { "ja": "レジェンド", "en": "Legendary" },
   "rarity.ll":                 { "ja": "LL",         "en": "LL" },
 
-  "footer.meta":               { "ja": "MyCryptoTactics Ver.1.1.0 · 非営利のファン制作", "en": "MyCryptoTactics Ver.1.1.0 · Non-commercial fan project" },
+  "footer.meta":               { "ja": "MyCryptoTactics Ver.1.2.0 · 非営利のファン制作", "en": "MyCryptoTactics Ver.1.2.0 · Non-commercial fan project" },
   "footer.credit":             { "ja": "キャラクター画像 / BGM / SE は My Crypto Heroes (MCH Co., Ltd.) に帰属します。", "en": "Character artwork / BGM / SFX belong to My Crypto Heroes (MCH Co., Ltd.)." },
   "footer.source":             { "ja": "ソースコード", "en": "Source code" },
 

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>MyCryptoTactics — Ver.1.1.0</title>
+  <title>MyCryptoTactics — Ver.1.2.0</title>
   <meta name="description" content="My Crypto Heroes の偉人たち × ローグライク × カードバトルのファンメイドブラウザゲーム。" />
 
   <!-- favicon -->
@@ -11,7 +11,7 @@
 
   <!-- Open Graph / Twitter Card (X リンクプレビュー用) -->
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="MyCryptoTactics — Ver.1.1.0" />
+  <meta property="og:title" content="MyCryptoTactics — Ver.1.2.0" />
   <meta property="og:description" content="My Crypto Heroes の偉人たち × ローグライク × カードバトル。スマホ・PC で遊べるブラウザゲーム。" />
   <meta property="og:url" content="https://mycryptotactics.vercel.app/" />
   <meta property="og:image" content="https://mycryptotactics.vercel.app/og-image.png" />
@@ -19,7 +19,7 @@
   <meta property="og:image:height" content="1536" />
   <meta property="og:site_name" content="MyCryptoTactics" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="MyCryptoTactics — Ver.1.1.0" />
+  <meta name="twitter:title" content="MyCryptoTactics — Ver.1.2.0" />
   <meta name="twitter:description" content="My Crypto Heroes 偉人 × ローグライク × カードバトル。" />
   <meta name="twitter:image" content="https://mycryptotactics.vercel.app/og-image.png" />
 
@@ -2669,7 +2669,7 @@
       <button type="button" class="lang-btn" data-lang="ja" data-i18n="lang.ja">JP：日本語</button>
       <button type="button" class="lang-btn" data-lang="en" data-i18n="lang.en">EN：English</button>
     </div>
-    <p class="title-version">Ver.1.1.0</p>
+    <p class="title-version">Ver.1.2.0</p>
   </div>
 
   <div class="wrap">
@@ -2861,6 +2861,7 @@
       <div class="rk-header">
         <h2 data-i18n="ranking.title">ランキング</h2>
         <div class="rk-controls">
+          <select data-rk-version-filter data-i18n-attr-aria-label="ranking.version" aria-label="バージョンでフィルタ"></select>
           <select data-rk-filter data-i18n-attr-aria-label="ranking.regulation" aria-label="レギュレーションでフィルタ"></select>
           <button type="button" class="action" data-rk-refresh data-i18n="ranking.refresh">更新</button>
           <button type="button" class="action" data-rk-back data-i18n="craft.back">← 戻る</button>
@@ -3018,7 +3019,7 @@
   </div>
 
   <footer>
-    <span class="footer-meta" data-i18n="footer.meta">MyCryptoTactics Ver.1.1.0 · 非営利のファン制作</span>
+    <span class="footer-meta" data-i18n="footer.meta">MyCryptoTactics Ver.1.2.0 · 非営利のファン制作</span>
     <span class="footer-credit" data-i18n-html="footer.credit.full">
       キャラクター画像 / BGM / SE は <strong>My Crypto Heroes (MCH Co., Ltd.)</strong> に帰属します。
       利用条件・権利表記・二次創作ガイドラインは
@@ -3178,7 +3179,7 @@
             <li><strong>?</strong> — ランダム（その時点の生存者から無作為に選択）。</li>
             <li><strong>PHY↑ / HP↓</strong> 等 — そのステータスが<strong>最も高い / 低い</strong>対象を選択。</li>
           </ul>
-          <p style="font-size:0.78rem;color:var(--muted)">※ パーティ編成（3 人 vs 3 人）はVer.1.1.0から有効です。前衛・中衛・後衛の並びはタイトルから入って編成画面で確認できます。</p>
+          <p style="font-size:0.78rem;color:var(--muted)">※ パーティ編成（3 人 vs 3 人）はVer.1.2.0から有効です。前衛・中衛・後衛の並びはタイトルから入って編成画面で確認できます。</p>
         </section>
         <section class="help-page" data-help-page="battle" data-i18n-html="help.body.battle">
           <h3>バトルロジック（概要）</h3>

--- a/prototype/js/main.js
+++ b/prototype/js/main.js
@@ -225,6 +225,11 @@ function reachableNextNodeIds(lastNodeId) {
 // x は固定・y は activeMapStartY に委譲
 const MAP_START_X = 50;
 
+/** アプリのバージョン文字列。スコア送信時の version フィールドと、
+ *  ランキングのバージョンフィルタの「現在」デフォルト値に使う。
+ *  index.html / ui.json の表記と一致させること (Ver.X.Y.Z 形式)。 */
+const APP_VERSION = "1.2.0";
+
 // ─── 状態変数 ────────────────────────────────────────────────────
 let gold = 75;
 let view = "map";
@@ -7514,7 +7519,7 @@ function buildRankingPayload(playerName) {
     llExt: llExtCount,
     heroIds: partyHeroes.map(h => h.heroId),
     absoluteConfig: absConfig,
-    version: "1.1.0",
+    version: APP_VERSION,
     _breakdown: breakdown,
   };
 }
@@ -7598,11 +7603,54 @@ async function openRankingView() {
   await renderRankingView();
 }
 
+/** ランキングのバージョン選択肢を、取得済みエントリから動的に組み立てる。
+ *  - APP_VERSION (現在実行中) は必ず先頭・デフォルト選択
+ *  - "" (= 全バージョン) を末尾に
+ *  - データから見つかったバージョンは新しい順 (semver 風 desc) に並べる
+ *  - 既存値があれば保持。デフォルトは APP_VERSION。
+ *  @param {Set<string>} versionsFromData
+ *  @param {string} currentValue */
+function rebuildRankingVersionOptions(selectEl, versionsFromData, currentValue) {
+  if (!selectEl) return;
+  const seen = new Set();
+  const opts = [];
+  // 1. 現在バージョンを先頭・必ず含める
+  seen.add(APP_VERSION);
+  opts.push({ value: APP_VERSION, label: `v${APP_VERSION} (current)` });
+  // 2. データから収集したバージョンを semver desc でソートして追加 (現バージョン以外)
+  const others = [...versionsFromData].filter(v => v && v !== APP_VERSION);
+  others.sort((a, b) => {
+    const pa = String(a).split(".").map(n => parseInt(n, 10) || 0);
+    const pb = String(b).split(".").map(n => parseInt(n, 10) || 0);
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+      const da = pa[i] || 0, db = pb[i] || 0;
+      if (da !== db) return db - da; // desc
+    }
+    return 0;
+  });
+  for (const v of others) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    opts.push({ value: v, label: `v${v}` });
+  }
+  // 3. "全バージョン" 末尾
+  opts.push({ value: "__all__", label: ti18n("ranking.version.all") });
+  // 4. 旧データ (version 未設定) を表示するためのオプション
+  if (versionsFromData.has("")) {
+    opts.push({ value: "__legacy__", label: ti18n("ranking.version.legacy") });
+  }
+  selectEl.innerHTML = opts.map(o => `<option value="${escapeHtml(o.value)}">${escapeHtml(o.label)}</option>`).join("");
+  // デフォルト選択: 現在値が候補に残っていればそれ、無ければ APP_VERSION
+  const target = opts.find(o => o.value === currentValue) ? currentValue : APP_VERSION;
+  selectEl.value = target;
+}
+
 async function renderRankingView() {
   const el = document.getElementById("rankingView");
   if (!el) return;
   const apiUrl = getRankingApiUrl();
   const filterEl = el.querySelector("[data-rk-filter]");
+  const versionFilterEl = el.querySelector("[data-rk-version-filter]");
   const listEl = el.querySelector("[data-rk-list]");
   const apiUrlInput = el.querySelector("[data-rk-apiurl]");
   if (apiUrlInput) apiUrlInput.value = apiUrl || "";
@@ -7613,22 +7661,42 @@ async function renderRankingView() {
   }
   listEl.innerHTML = `<p class="rk-msg">${escapeHtml(ti18n("ranking.fetching"))}</p>`;
   const filterId = filterEl?.value || "";
-  const result = await fetchRanking({ regulation: filterId || undefined, limit: 50 });
+  const result = await fetchRanking({ regulation: filterId || undefined, limit: 200 });
   if (!result.ok) {
     listEl.innerHTML = `<p class="rk-msg rk-msg--error">${escapeHtml(ti18n("ranking.fetch.error"))}: ${escapeHtml(result.error || "unknown")}</p>`;
     return;
   }
-  if (!result.ranking || result.ranking.length === 0) {
+  // バージョン選択肢を更新 (取得済みデータから unique versions を抽出)
+  const versionsFromData = new Set();
+  for (const e of (result.ranking || [])) versionsFromData.add(e.version || "");
+  rebuildRankingVersionOptions(versionFilterEl, versionsFromData, versionFilterEl?.value || APP_VERSION);
+  const selectedVer = versionFilterEl?.value || APP_VERSION;
+
+  // バージョンフィルタ (client-side)
+  let filtered = result.ranking || [];
+  if (selectedVer === "__legacy__") {
+    filtered = filtered.filter(e => !e.version);
+  } else if (selectedVer === "__all__") {
+    // no-op
+  } else {
+    filtered = filtered.filter(e => (e.version || "") === selectedVer);
+  }
+
+  if (filtered.length === 0) {
     listEl.innerHTML = `<p class="rk-msg">${escapeHtml(ti18n("ranking.empty"))}</p>`;
     return;
   }
-  const rows = result.ranking.map(e => {
+  // 表示件数は 50 まで
+  const display = filtered.slice(0, 50);
+  const rows = display.map((e, idx) => {
+    // 元の `e.rank` はサーバ側全体順位なので、フィルタ後の表示順位 (1, 2, …) を採用
+    const rank = idx + 1;
     const regJa = REGULATION_BY_ID[e.regulation]?.nameJa || e.regulation;
     const absInfo = e.absolute
       ? ` <span class="rk-abs">[eHP×${e.absolute.enemyHpMult} eDmg×${e.absolute.enemyDmgMult} sHP×${e.absolute.playerHpMult} sDmg×${e.absolute.playerDmgMult}]</span>`
       : "";
     return `<tr>
-      <td class="rk-rank">${e.rank}</td>
+      <td class="rk-rank">${rank}</td>
       <td class="rk-name">${escapeHtml(e.playerName)}</td>
       <td class="rk-score">${e.score.toLocaleString()}</td>
       <td class="rk-reg">${escapeHtml(regJa)}${absInfo}</td>
@@ -7654,6 +7722,14 @@ async function renderRankingView() {
         .concat(REGULATIONS.map(r => `<option value="${r.id}">${r.nameJa}</option>`));
       filterEl.innerHTML = opts.join("");
       filterEl.addEventListener("change", () => renderRankingView());
+    }
+    // バージョンフィルタの change → 再描画 (実 fetch は再走、選択値は維持)
+    const verEl = el.querySelector("[data-rk-version-filter]");
+    if (verEl) {
+      // 初期値として APP_VERSION を入れておく (renderRankingView 内で
+      // データ取得後に rebuild される際の current 保持に使う)
+      verEl.innerHTML = `<option value="${escapeHtml(APP_VERSION)}">v${escapeHtml(APP_VERSION)} (current)</option>`;
+      verEl.addEventListener("change", () => renderRankingView());
     }
     el.querySelector("[data-rk-refresh]")?.addEventListener("click", () => renderRankingView());
     el.querySelector("[data-rk-back]")?.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
ランキングをバージョン別に表示できるようにし、Ver.1.2.0 としてリリース。

## バージョン bump (Ver.1.1.0 → Ver.1.2.0)
- [index.html](prototype/index.html): \`<title>\` / og:title / twitter:title / フッター / 編成画面案内文 / タイトル画面下部の \`.title-version\` ピル
- [ui.json](prototype/data/i18n/ui.json): \`footer.meta\` (JA/EN)
- [main.js](prototype/js/main.js): ランキング送信 payload の \`version\` フィールドを新規 \`APP_VERSION\` 定数に統一

## APP_VERSION 定数
[main.js](prototype/js/main.js) 上部に single source of truth:

\`\`\`js
const APP_VERSION = \"1.2.0\";
\`\`\`

次回 bump 時はこの 1 行 + index.html / ui.json の表示テキストだけ書き換えれば OK。

## バージョン別ランキングフィルタ
ランキング画面の controls にレギュレーションフィルタの隣 \`<select data-rk-version-filter>\` を追加。

| 項目 | 動作 |
|---|---|
| **デフォルト選択** | APP_VERSION (\"v1.2.0 (current)\") |
| その他のバージョン | 取得データから動的に抽出、semver desc で並べる (新しい順) |
| **「全バージョン / All versions」** | バージョン filter を無効化 |
| **「旧版 / Legacy」** | \`version\` フィールド未設定の旧データ表示 (beta1 等の互換性) |

実装は **client-side**:
- fetch limit を 200 に引き上げ → filter → 上位 50 表示
- 表示順位はフィルタ後の連番 (1, 2, …) を使用 (サーバ側 global rank はクロスバージョンで意味がないため)

i18n キー: \`ranking.version\` / \`ranking.version.all\` / \`ranking.version.legacy\`

## Verified in Launch preview
- Title / og / footer すべて Ver.1.2.0
- ランキング dropdown が実データから構築: \`v1.2.0 (current) / v1.1.0 / vbeta1 / vbeta1-seed / 全バージョン\`
- デフォルト v1.2.0 = 空 (まだエントリ無し、本リリースのみ可視)
- v1.1.0 へ切替 → 10 行表示
- 「全バージョン」へ切替 → 50 行表示 (上限)

## Test plan
- [ ] タイトル画面の Ver 表示が Ver.1.2.0
- [ ] ブラウザタブ / フッター / OG / Twitter プレビューも Ver.1.2.0
- [ ] ランキング画面開いた時、バージョン filter が **v1.2.0 (current)** に選択された状態
- [ ] 1.2.0 でクリアして送信 → そのエントリが v1.2.0 に表示される
- [ ] バージョン dropdown を v1.1.0 に切替 → 過去エントリが見える
- [ ] 「全バージョン」「旧版」フィルタも動作
- [ ] レギュレーション filter とバージョン filter の **AND** 適用が効く